### PR TITLE
Add support for some extended parameters of llama.cpp(top_k, top_p, min_p, and repeat_penalty)

### DIFF
--- a/src/main/java/ee/carlrobert/llm/client/llama/completion/LlamaCompletionRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/llama/completion/LlamaCompletionRequest.java
@@ -8,12 +8,20 @@ public class LlamaCompletionRequest implements CompletionRequest {
   private final int n_predict;
   private final boolean stream;
   private final double temperature;
+  private final int top_k;
+  private final double top_p;
+  private final double min_p;
+  private final double repeat_penalty;
 
   public LlamaCompletionRequest(Builder builder) {
     this.prompt = builder.prompt;
     this.stream = builder.stream;
     this.n_predict = builder.n_predict;
     this.temperature = builder.temperature;
+    this.top_k = builder.top_k;
+    this.top_p = builder.top_p;
+    this.min_p = builder.min_p;
+    this.repeat_penalty = builder.repeat_penalty;
   }
 
   public String getPrompt() {
@@ -32,12 +40,32 @@ public class LlamaCompletionRequest implements CompletionRequest {
     return temperature;
   }
 
+  public int getTop_k() {
+    return top_k;
+  }
+
+  public double getTop_p() {
+    return top_p;
+  }
+
+  public double getMin_p() {
+    return min_p;
+  }
+
+  public double getRepeat_penalty() {
+    return repeat_penalty;
+  }
+
   public static class Builder {
 
     private final String prompt;
     private boolean stream = true;
     private int n_predict = 256;
     private double temperature = 0.1;
+    private int top_k = 40;
+    private double top_p = 0.9;
+    private double min_p = 0.05;
+    private double repeat_penalty = 1.1;
 
     public Builder(String prompt) {
       this.prompt = prompt;
@@ -55,6 +83,26 @@ public class LlamaCompletionRequest implements CompletionRequest {
 
     public Builder setTemperature(double temperature) {
       this.temperature = temperature;
+      return this;
+    }
+
+    public Builder setTop_k(int top_k) {
+      this.top_k = top_k;
+      return this;
+    }
+
+    public Builder setTop_p(double top_p) {
+      this.top_p = top_p;
+      return this;
+    }
+
+    public Builder setMin_p(double min_p) {
+      this.min_p = min_p;
+      return this;
+    }
+
+    public Builder setRepeat_penalty(double repeat_penalty) {
+      this.repeat_penalty = repeat_penalty;
       return this;
     }
 

--- a/src/test/java/ee/carlrobert/llm/client/LlamaClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/LlamaClientTest.java
@@ -23,8 +23,9 @@ public class LlamaClientTest extends BaseTest {
       assertThat(request.getUri().getPath()).isEqualTo("/completion");
       assertThat(request.getMethod()).isEqualTo("POST");
       assertThat(request.getBody())
-          .extracting("prompt", "stream", "n_predict", "temperature")
-          .containsExactly("TEST_PROMPT", true, 10, 0.1);
+          .extracting("prompt", "stream", "n_predict", "temperature", "top_k", "top_p", "min_p",
+              "repeat_penalty")
+          .containsExactly("TEST_PROMPT", true, 10, 0.1, 40, 0.9, 0.05, 1.1);
       assertThat(request.getHeaders())
           .flatExtracting("Accept", "Connection")
           .containsExactly("text/event-stream", "Keep-Alive");
@@ -56,8 +57,9 @@ public class LlamaClientTest extends BaseTest {
       assertThat(request.getUri().getPath()).isEqualTo("/completion");
       assertThat(request.getMethod()).isEqualTo("POST");
       assertThat(request.getBody())
-          .extracting("prompt", "stream", "n_predict", "temperature")
-          .containsExactly("TEST_PROMPT", false, 10, 0.5);
+          .extracting("prompt", "stream", "n_predict", "temperature", "top_k", "top_p", "min_p",
+              "repeat_penalty")
+          .containsExactly("TEST_PROMPT", false, 10, 0.5, 40, 0.9, 0.05, 1.1);
       return new ResponseEntity(jsonMapResponse("content", "Hello!"));
     });
 
@@ -67,6 +69,10 @@ public class LlamaClientTest extends BaseTest {
             .setStream(false)
             .setN_predict(10)
             .setTemperature(0.5)
+            .setTop_k(40)
+            .setTop_p(0.9)
+            .setMin_p(0.05)
+            .setRepeat_penalty(1.1)
             .build());
 
     assertThat(response.getContent()).isEqualTo("Hello!");


### PR DESCRIPTION
- Added 'top_k,' 'top_p,' 'min_p,' and 'repeat_penalty' fields to the LlamaCompletionRequest class, utilizing default values from the llama.cpp documentation. If left untouched, these fields do not impact the model's response to the request.

In these URL there is information about those values:
https://www.reddit.com/r/LocalLLaMA/comments/17vonjo/your_settings_are_probably_hurting_your_model_why/
https://github.com/huggingface/transformers/issues/27670