### PR TITLE
Add Llama api key authentication option

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "ee.carlrobert"
-version = "0.3.0"
+version = "0.3.1"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
* Adds `apiKey` to `LLamaClient`, if set the `Authorization` Header will be set to the `apiKey` (bearer), as documented in [llama.cpp/server/README.md](https://github.com/ggerganov/llama.cpp/tree/master/examples/server)
* Fixed concatenation of the path, if custom `host` is used