### PR TITLE
Add Ollama API Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EventSource call = client.getChatCompletion(
         .setModel(OpenAIChatCompletionModel.GPT_4)
         .setTemperature(0.1)
         .build(),
-    new CompletionEventListener() {
+    new CompletionEventListener<String>(){
       @Override
       public void onMessage(String message) {
         System.out.println(message);

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "ee.carlrobert"
-version = "0.4.0"
+version = "0.3.1"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "ee.carlrobert"
-version = "0.3.1"
+version = "0.4.0"
 
 repositories {
     mavenCentral()
@@ -89,12 +89,12 @@ publishing {
     }
 }
 
-signing {
-    val signingKey = (findProperty("signingKey") ?: "") as String
-    val signingPassword = (findProperty("signingPassword") ?: "") as String
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications["mavenJava"])
-}
+//signing {
+//    val signingKey = (findProperty("signingKey") ?: "") as String
+//    val signingPassword = (findProperty("signingPassword") ?: "") as String
+//    useInMemoryPgpKeys(signingKey, signingPassword)
+//    sign(publishing.publications["mavenJava"])
+//}
 
 tasks {
     test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,12 +89,12 @@ publishing {
     }
 }
 
-//signing {
-//    val signingKey = (findProperty("signingKey") ?: "") as String
-//    val signingPassword = (findProperty("signingPassword") ?: "") as String
-//    useInMemoryPgpKeys(signingKey, signingPassword)
-//    sign(publishing.publications["mavenJava"])
-//}
+signing {
+    val signingKey = (findProperty("signingKey") ?: "") as String
+    val signingPassword = (findProperty("signingPassword") ?: "") as String
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications["mavenJava"])
+}
 
 tasks {
     test {

--- a/src/main/java/ee/carlrobert/llm/client/StreamableRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/StreamableRequest.java
@@ -1,0 +1,7 @@
+package ee.carlrobert.llm.client;
+
+public interface StreamableRequest {
+
+  Boolean isStream();
+
+}

--- a/src/main/java/ee/carlrobert/llm/client/llama/completion/LlamaCompletionRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/llama/completion/LlamaCompletionRequest.java
@@ -32,7 +32,7 @@ public class LlamaCompletionRequest implements CompletionRequest {
     return prompt;
   }
 
-  public boolean isStream() {
+  public Boolean isStream() {
     return stream;
   }
 

--- a/src/main/java/ee/carlrobert/llm/client/ollama/OllamaClient.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/OllamaClient.java
@@ -1,0 +1,255 @@
+package ee.carlrobert.llm.client.ollama;
+
+import static java.lang.String.format;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ee.carlrobert.llm.PropertiesLoader;
+import ee.carlrobert.llm.client.DeserializationUtil;
+import ee.carlrobert.llm.client.StreamableRequest;
+import ee.carlrobert.llm.client.ollama.completion.request.OllamaCompletionRequest;
+import ee.carlrobert.llm.client.ollama.completion.request.OllamaEmbeddingRequest;
+import ee.carlrobert.llm.client.ollama.completion.request.OllamaPullRequest;
+import ee.carlrobert.llm.client.ollama.completion.response.OllamaCompletionResponse;
+import ee.carlrobert.llm.client.ollama.completion.response.OllamaEmbeddingResponse;
+import ee.carlrobert.llm.client.ollama.completion.response.OllamaModelInfoResponse;
+import ee.carlrobert.llm.client.ollama.completion.response.OllamaPullResponse;
+import ee.carlrobert.llm.client.ollama.completion.response.OllamaTagsResponse;
+import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
+import ee.carlrobert.llm.completion.CompletionEventListener;
+import ee.carlrobert.llm.completion.CompletionEventSourceListener;
+import java.io.IOException;
+import java.util.Map;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.sse.EventSource;
+import okhttp3.sse.EventSources;
+import org.jetbrains.annotations.NotNull;
+
+public class OllamaClient {
+
+  private static final String BASE_URL = PropertiesLoader.getValue("ollama.baseUrl");
+
+  private final OkHttpClient httpClient;
+  private final String host;
+  private final Integer port;
+
+  protected OllamaClient(Builder builder, OkHttpClient.Builder httpClientBuilder) {
+    httpClientBuilder
+        .addInterceptor(new Interceptor() {
+          @NotNull
+          @Override
+          public Response intercept(@NotNull Chain chain) throws IOException {
+            Request request = chain.request();
+            Response response = chain.proceed(request);
+            // Workaround since OkHttp does not recognize "application/x-ndjson" as a valid stream
+            // Content-Type
+            // see: RealEventSource.kt ResponseBody.isEventStream()
+            if (response.header("Content-Type", "")
+                .equals("application/x-ndjson")) {
+              return convertNDJsonToTextEventStreamResponse(response);
+            }
+            return response;
+          }
+        });
+    this.httpClient = httpClientBuilder.build();
+    this.host = builder.host;
+    this.port = builder.port;
+  }
+
+  @NotNull
+  private static Response convertNDJsonToTextEventStreamResponse(Response response)
+      throws IOException {
+    String ndJsonString = response.body().string();
+    String textEventString = ndJsonString
+        .replace("{\"model\"", "data: {\"model\"")
+        .replace("}\n", "}\n\n");
+    return response
+        .newBuilder()
+        .header("Content-Type", "text/event-stream")
+        .body(ResponseBody.create(textEventString, MediaType.get("text/event-stream")))
+        .build();
+  }
+
+  public EventSource getChatCompletionAsync(
+      OllamaCompletionRequest request,
+      CompletionEventListener<String> eventListener) {
+    return EventSources.createFactory(httpClient)
+        .newEventSource(buildCompletionHttpRequest(request),
+            getCompletionEventSourceListener(eventListener));
+  }
+
+  public OllamaCompletionResponse getChatCompletion(OllamaCompletionRequest request) {
+    try (var response = httpClient.newCall(buildCompletionHttpRequest(request)).execute()) {
+      return DeserializationUtil.mapResponse(response, OllamaCompletionResponse.class);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Could not get ollama completion for the given request:\n" + request, e);
+    }
+  }
+
+  public OllamaEmbeddingResponse getEmbedding(OllamaEmbeddingRequest request) {
+    try (var response = httpClient.newCall(
+            buildPostRequest(request, "/api/embeddings", false))
+        .execute()) {
+      return DeserializationUtil.mapResponse(response, OllamaEmbeddingResponse.class);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Could not get ollama embedding for the given request:\n" + request, e);
+    }
+  }
+
+  public OllamaPullResponse pullModel(OllamaPullRequest request) {
+    try (var response = httpClient.newCall(buildPostRequest(request, "/api/pull")).execute()) {
+      return DeserializationUtil.mapResponse(response, OllamaPullResponse.class);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Could not pull ollama model for the given request:\n" + request, e);
+    }
+  }
+
+  public EventSource pullModelAsync(
+      OllamaPullRequest request,
+      CompletionEventListener<OllamaPullResponse> eventListener) {
+    return EventSources.createFactory(httpClient)
+        .newEventSource(buildPostRequest(request, "/api/pull"),
+            getPullModelEventSourceListener(eventListener));
+  }
+
+
+  public boolean deleteModel(String model) {
+    try (var response = httpClient.newCall(defaultRequest("/api/delete", false)
+        .delete(createRequestBody(Map.of("name", model))).build()).execute()) {
+      return response.isSuccessful();
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Could not delete ollama model for the given model name:\n" + model, e);
+    }
+  }
+
+  public OllamaTagsResponse getModelTags() {
+    try (var response = httpClient.newCall(defaultRequest("/api/tags", false).get().build())
+        .execute()) {
+      return DeserializationUtil.mapResponse(response, OllamaTagsResponse.class);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Could not get ollama model tags:\n", e);
+    }
+  }
+
+  public OllamaModelInfoResponse getModelInfo(String model) {
+    try (var response = httpClient.newCall(
+            buildPostRequest(Map.of("name", model), "/api/show", false))
+        .execute()) {
+      return DeserializationUtil.mapResponse(response, OllamaModelInfoResponse.class);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Could not get ollama model info for the given model name:\n" + model, e);
+    }
+  }
+
+  private Request buildCompletionHttpRequest(OllamaCompletionRequest request) {
+    return buildPostRequest(request, "/api/generate");
+  }
+
+  private Request buildPostRequest(StreamableRequest request, String path) {
+    return buildPostRequest(request, path, request.isStream());
+  }
+
+  private Request buildPostRequest(Object request, String path, boolean isStream) {
+    try {
+      return defaultRequest(path, isStream)
+          .post(createRequestBody(request))
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @NotNull
+  private static RequestBody createRequestBody(Object request) throws JsonProcessingException {
+    return RequestBody.create(
+        new ObjectMapper().writeValueAsString(request),
+        MediaType.parse("application/json"));
+  }
+
+  private Request.Builder defaultRequest(String path, boolean stream) {
+    var baseHost = port == null ? BASE_URL : format("http://localhost:%d", port);
+    return new Request.Builder()
+        .url((host == null ? baseHost : host) + path)
+        .header("Cache-Control", "no-cache")
+        .header("Content-Type", "application/json")
+        .header("Accept", stream ? "text/event-stream" : "text/json");
+  }
+
+  private CompletionEventSourceListener getCompletionEventSourceListener(
+      CompletionEventListener eventListener) {
+    return new CompletionEventSourceListener(eventListener) {
+      @Override
+      protected String getMessage(String data) {
+        try {
+          var response = new ObjectMapper().readValue(data, OllamaCompletionResponse.class);
+          return response.getResponse();
+        } catch (JacksonException e) {
+          // ignore
+        }
+        return "";
+      }
+
+      @Override
+      protected ErrorDetails getErrorDetails(String error) {
+        return new ErrorDetails(error);
+      }
+    };
+  }
+
+  private CompletionEventSourceListener<OllamaPullResponse> getPullModelEventSourceListener(
+      CompletionEventListener<OllamaPullResponse> eventListener) {
+    return new CompletionEventSourceListener<>(eventListener) {
+      @Override
+      protected OllamaPullResponse getMessage(String data) {
+        try {
+          return new ObjectMapper().readValue(data, OllamaPullResponse.class);
+        } catch (JacksonException e) {
+          // ignore
+        }
+        return null;
+      }
+
+      @Override
+      protected ErrorDetails getErrorDetails(String error) {
+        return new ErrorDetails(error);
+      }
+    };
+  }
+
+  public static class Builder {
+
+    private String host;
+    private Integer port;
+
+    public Builder setHost(String host) {
+      this.host = host;
+      return this;
+    }
+
+    public Builder setPort(Integer port) {
+      this.port = port;
+      return this;
+    }
+
+    public OllamaClient build(OkHttpClient.Builder builder) {
+      return new OllamaClient(this, builder);
+    }
+
+    public OllamaClient build() {
+      return build(new OkHttpClient.Builder());
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/OllamaClient.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/OllamaClient.java
@@ -66,15 +66,23 @@ public class OllamaClient {
   @NotNull
   private static Response convertNDJsonToTextEventStreamResponse(Response response)
       throws IOException {
-    String ndJsonString = response.body().string();
-    String textEventString = ndJsonString
-        .replace("{\"model\"", "data: {\"model\"")
-        .replace("}\n", "}\n\n");
     return response
         .newBuilder()
         .header("Content-Type", "text/event-stream")
-        .body(ResponseBody.create(textEventString, MediaType.get("text/event-stream")))
+        .body(ResponseBody.create(convertNdJsonToEventStream(response.body().string()),
+            MediaType.get("text/event-stream")))
         .build();
+  }
+
+  private static String convertNdJsonToEventStream(String ndjsonString) {
+    StringBuilder eventStreamBuilder = new StringBuilder();
+    String[] lines = ndjsonString.split("\n");
+    for (String line : lines) {
+      if (!line.isEmpty()) {
+        eventStreamBuilder.append("data: " + line + "\n\n");
+      }
+    }
+    return eventStreamBuilder.toString();
   }
 
   public EventSource getChatCompletionAsync(

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/request/OllamaCompletionRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/request/OllamaCompletionRequest.java
@@ -1,0 +1,133 @@
+package ee.carlrobert.llm.client.ollama.completion.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import ee.carlrobert.llm.client.StreamableRequest;
+import ee.carlrobert.llm.client.ollama.completion.response.OllamaResponseFormat;
+import ee.carlrobert.llm.completion.CompletionRequest;
+
+/*
+ * See <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion">ollama/api</a>
+ */
+@JsonInclude(Include.NON_NULL)
+public class OllamaCompletionRequest implements CompletionRequest, StreamableRequest {
+
+  private final String model;
+  private final String prompt;
+
+  private final OllamaResponseFormat format;
+  private final OllamaParameters options;
+  private final String system;
+  private final String template;
+  private final String context;
+  private final Boolean stream;
+  private final Boolean raw;
+
+
+  public OllamaCompletionRequest(Builder builder) {
+    this.prompt = builder.prompt;
+    this.model = builder.model;
+    this.format = builder.format;
+    this.options = builder.options;
+    this.system = builder.system;
+    this.template = builder.template;
+    this.context = builder.context;
+    this.stream = builder.stream;
+    this.raw = builder.raw;
+  }
+
+  public String getModel() {
+    return model;
+  }
+
+  public String getPrompt() {
+    return prompt;
+  }
+
+  public OllamaResponseFormat getFormat() {
+    return format;
+  }
+
+  public OllamaParameters getOptions() {
+    return options;
+  }
+
+  public String getSystem() {
+    return system;
+  }
+
+  public String getTemplate() {
+    return template;
+  }
+
+  public String getContext() {
+    return context;
+  }
+
+  public Boolean isStream() {
+    return stream;
+  }
+
+  public Boolean isRaw() {
+    return raw;
+  }
+
+  public static class Builder {
+
+    private final String model;
+    private final String prompt;
+
+    private OllamaResponseFormat format = null;
+    private OllamaParameters options = null;
+    private String system = null;
+    private String template = null;
+    private String context = null;
+    private boolean stream = false;
+    private boolean raw = false;
+
+    public Builder(String model, String prompt) {
+      this.model = model;
+      this.prompt = prompt;
+    }
+
+    public Builder setFormat(OllamaResponseFormat format) {
+      this.format = format;
+      return Builder.this;
+    }
+
+    public Builder setOptions(OllamaParameters options) {
+      this.options = options;
+      return Builder.this;
+    }
+
+    public Builder setSystem(String system) {
+      this.system = system;
+      return Builder.this;
+    }
+
+    public Builder setTemplate(String template) {
+      this.template = template;
+      return Builder.this;
+    }
+
+    public Builder setContext(String context) {
+      this.context = context;
+      return Builder.this;
+    }
+
+    public Builder setStream(boolean stream) {
+      this.stream = stream;
+      return Builder.this;
+    }
+
+    public Builder setRaw(boolean raw) {
+      this.raw = raw;
+      return Builder.this;
+    }
+
+    public OllamaCompletionRequest build() {
+      return new OllamaCompletionRequest(this);
+    }
+
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/request/OllamaEmbeddingRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/request/OllamaEmbeddingRequest.java
@@ -1,0 +1,54 @@
+package ee.carlrobert.llm.client.ollama.completion.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/*
+ * See <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion">ollama/api</a>
+ */
+@JsonInclude(Include.NON_NULL)
+public class OllamaEmbeddingRequest {
+
+  private final String model;
+  private final String prompt;
+  private final OllamaParameters options;
+
+  public OllamaEmbeddingRequest(Builder builder) {
+    this.prompt = builder.prompt;
+    this.model = builder.model;
+    this.options = builder.options;
+  }
+
+  public String getModel() {
+    return model;
+  }
+
+  public String getPrompt() {
+    return prompt;
+  }
+
+  public OllamaParameters getOptions() {
+    return options;
+  }
+
+  public static class Builder {
+
+    private final String model;
+    private final String prompt;
+    private OllamaParameters options = null;
+
+    public Builder(String model, String prompt) {
+      this.model = model;
+      this.prompt = prompt;
+    }
+
+    public OllamaEmbeddingRequest.Builder setOptions(OllamaParameters options) {
+      this.options = options;
+      return OllamaEmbeddingRequest.Builder.this;
+    }
+
+    public OllamaEmbeddingRequest build() {
+      return new OllamaEmbeddingRequest(this);
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/request/OllamaParameters.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/request/OllamaParameters.java
@@ -1,0 +1,219 @@
+package ee.carlrobert.llm.client.ollama.completion.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/*
+ * See <a href="https://github.com/ollama/ollama/blob/main/docs/modelfile.md#parameter">ollama/api</a>
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class OllamaParameters {
+
+  private final Integer mirostat;
+  private final Double mirostatEta;
+  private final Double mirostatTau;
+  private final Integer numCtx;
+  private final Integer numGqa;
+  private final Integer numGpu;
+  private final Integer numThread;
+  private final Integer repeatLastN;
+  private final Double repeatPenalty;
+  private final Double temperature;
+  private final Integer seed;
+  private final String stop;
+  private final Double tfsZ;
+  private final Integer numPredict;
+  private final Integer topK;
+  private final Double topP;
+
+  public OllamaParameters(Builder builder) {
+    this.mirostat = builder.mirostat;
+    this.mirostatEta = builder.mirostatEta;
+    this.mirostatTau = builder.mirostatTau;
+    this.numCtx = builder.numCtx;
+    this.numGqa = builder.numGqa;
+    this.numGpu = builder.numGpu;
+    this.numThread = builder.numThread;
+    this.repeatLastN = builder.repeatLastN;
+    this.repeatPenalty = builder.repeatPenalty;
+    this.temperature = builder.temperature;
+    this.seed = builder.seed;
+    this.stop = builder.stop;
+    this.tfsZ = builder.tfsZ;
+    this.numPredict = builder.numPredict;
+    this.topK = builder.topK;
+    this.topP = builder.topP;
+  }
+
+
+  public Integer getMirostat() {
+    return mirostat;
+  }
+
+  public Double getMirostatEta() {
+    return mirostatEta;
+  }
+
+  public Double getMirostatTau() {
+    return mirostatTau;
+  }
+
+  public Integer getNumCtx() {
+    return numCtx;
+  }
+
+  public Integer getNumGqa() {
+    return numGqa;
+  }
+
+  public Integer getNumGpu() {
+    return numGpu;
+  }
+
+  public Integer getNumThread() {
+    return numThread;
+  }
+
+  public Integer getRepeatLastN() {
+    return repeatLastN;
+  }
+
+  public Double getRepeatPenalty() {
+    return repeatPenalty;
+  }
+
+  public Double getTemperature() {
+    return temperature;
+  }
+
+  public Integer getSeed() {
+    return seed;
+  }
+
+  public String getStop() {
+    return stop;
+  }
+
+  public Double getTfsZ() {
+    return tfsZ;
+  }
+
+  public Integer getNumPredict() {
+    return numPredict;
+  }
+
+  public Integer getTopK() {
+    return topK;
+  }
+
+  public Double getTopP() {
+    return topP;
+  }
+
+  public static class Builder {
+
+    private Integer mirostat;
+    private Double mirostatEta;
+    private Double mirostatTau;
+    private Integer numCtx;
+    private Integer numGqa;
+    private Integer numGpu;
+    private Integer numThread;
+    private Integer repeatLastN;
+    private Double repeatPenalty;
+    private Double temperature;
+    private Integer seed;
+    private String stop;
+    private Double tfsZ;
+    private Integer numPredict;
+    private Integer topK;
+    private Double topP;
+
+    public Builder() {
+      // Default values
+    }
+
+    public Builder mirostat(Integer mirostat) {
+      this.mirostat = mirostat;
+      return this;
+    }
+
+    public Builder mirostatEta(Double mirostatEta) {
+      this.mirostatEta = mirostatEta;
+      return this;
+    }
+
+    public Builder mirostatTau(Double mirostatTau) {
+      this.mirostatTau = mirostatTau;
+      return this;
+    }
+
+    public Builder numCtx(Integer numCtx) {
+      this.numCtx = numCtx;
+      return this;
+    }
+
+    public Builder numGqa(Integer numGqa) {
+      this.numGqa = numGqa;
+      return this;
+    }
+
+    public Builder numGpu(Integer numGpu) {
+      this.numGpu = numGpu;
+      return this;
+    }
+
+    public Builder numThread(Integer numThread) {
+      this.numThread = numThread;
+      return this;
+    }
+
+    public Builder repeatLastN(Integer repeatLastN) {
+      this.repeatLastN = repeatLastN;
+      return this;
+    }
+
+    public Builder repeatPenalty(Double repeatPenalty) {
+      this.repeatPenalty = repeatPenalty;
+      return this;
+    }
+
+    public Builder temperature(Double temperature) {
+      this.temperature = temperature;
+      return this;
+    }
+
+    public Builder seed(Integer seed) {
+      this.seed = seed;
+      return this;
+    }
+
+    public Builder stop(String stop) {
+      this.stop = stop;
+      return this;
+    }
+
+    public Builder tfsZ(Double tfsZ) {
+      this.tfsZ = tfsZ;
+      return this;
+    }
+
+    public Builder numPredict(Integer numPredict) {
+      this.numPredict = numPredict;
+      return this;
+    }
+
+    public Builder topK(Integer topK) {
+      this.topK = topK;
+      return this;
+    }
+
+    public Builder topP(Double topP) {
+      this.topP = topP;
+      return this;
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/request/OllamaPullRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/request/OllamaPullRequest.java
@@ -1,0 +1,34 @@
+package ee.carlrobert.llm.client.ollama.completion.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import ee.carlrobert.llm.client.StreamableRequest;
+
+/*
+ * See <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#pull-a-model">ollama/api</a>
+ */
+@JsonInclude(Include.NON_NULL)
+public class OllamaPullRequest implements StreamableRequest {
+
+  private final String name;
+  private final Boolean stream;
+
+
+  public OllamaPullRequest(String name, Boolean stream) {
+    this.name = name;
+    this.stream = stream;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Boolean getStream() {
+    return stream;
+  }
+
+  @Override
+  public Boolean isStream() {
+    return stream;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaCompletionResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaCompletionResponse.java
@@ -1,0 +1,74 @@
+package ee.carlrobert.llm.client.ollama.completion.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class OllamaCompletionResponse {
+
+  private String model;
+  private String createdAt;
+  private String response;
+  private boolean done;
+  private int promptEvalCount;
+  private int evalCount;
+  private String context;
+
+  public String getModel() {
+    return model;
+  }
+
+  public void setModel(String model) {
+    this.model = model;
+  }
+
+  public String getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(String createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  public String getResponse() {
+    return response;
+  }
+
+  public void setResponse(String response) {
+    this.response = response;
+  }
+
+  public boolean isDone() {
+    return done;
+  }
+
+  public void setDone(boolean done) {
+    this.done = done;
+  }
+
+  public int getPromptEvalCount() {
+    return promptEvalCount;
+  }
+
+  public void setPromptEvalCount(int promptEvalCount) {
+    this.promptEvalCount = promptEvalCount;
+  }
+
+  public int getEvalCount() {
+    return evalCount;
+  }
+
+  public void setEvalCount(int evalCount) {
+    this.evalCount = evalCount;
+  }
+
+  public String getContext() {
+    return context;
+  }
+
+  public void setContext(String context) {
+    this.context = context;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaEmbeddingResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaEmbeddingResponse.java
@@ -1,0 +1,14 @@
+package ee.carlrobert.llm.client.ollama.completion.response;
+
+public class OllamaEmbeddingResponse {
+
+  private double[] embedding;
+
+  public double[] getEmbedding() {
+    return embedding;
+  }
+
+  public void setEmbedding(double[] embedding) {
+    this.embedding = embedding;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaModel.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaModel.java
@@ -1,0 +1,90 @@
+package ee.carlrobert.llm.client.ollama.completion.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class OllamaModel {
+
+  private String name;
+  private long size;
+  private OllamaModelDetails details;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public long getSize() {
+    return size;
+  }
+
+  public void setSize(long size) {
+    this.size = size;
+  }
+
+  public OllamaModelDetails getDetails() {
+    return details;
+  }
+
+  public void setDetails(OllamaModelDetails details) {
+    this.details = details;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+  public static class OllamaModelDetails {
+
+    private String format;
+    private String family;
+    private List<String> families;
+    private String parameterSize;
+    private String quantizationLevel;
+
+    public String getFormat() {
+      return format;
+    }
+
+    public void setFormat(String format) {
+      this.format = format;
+    }
+
+    public String getFamily() {
+      return family;
+    }
+
+    public void setFamily(String family) {
+      this.family = family;
+    }
+
+    public List<String> getFamilies() {
+      return families;
+    }
+
+    public void setFamilies(List<String> families) {
+      this.families = families;
+    }
+
+    public String getParameterSize() {
+      return parameterSize;
+    }
+
+    public void setParameterSize(String parameterSize) {
+      this.parameterSize = parameterSize;
+    }
+
+    public String getQuantizationLevel() {
+      return quantizationLevel;
+    }
+
+    public void setQuantizationLevel(String quantizationLevel) {
+      this.quantizationLevel = quantizationLevel;
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaModelInfoResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaModelInfoResponse.java
@@ -1,0 +1,54 @@
+package ee.carlrobert.llm.client.ollama.completion.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import ee.carlrobert.llm.client.ollama.completion.response.OllamaModel.OllamaModelDetails;
+
+
+/**
+ * see <a
+ * href="https://github.com/ollama/ollama/blob/main/docs/api.md#show-model-information">ollama/api</a>.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class OllamaModelInfoResponse {
+
+  private String modelfile;
+  private String parameters;
+  private String template;
+  private OllamaModelDetails details;
+
+  public String getModelfile() {
+    return modelfile;
+  }
+
+  public void setModelfile(String modelfile) {
+    this.modelfile = modelfile;
+  }
+
+  public String getParameters() {
+    return parameters;
+  }
+
+  public void setParameters(String parameters) {
+    this.parameters = parameters;
+  }
+
+  public String getTemplate() {
+    return template;
+  }
+
+  public void setTemplate(String template) {
+    this.template = template;
+  }
+
+  public OllamaModelDetails getDetails() {
+    return details;
+  }
+
+  public void setDetails(
+      OllamaModelDetails details) {
+    this.details = details;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaPullResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaPullResponse.java
@@ -1,0 +1,53 @@
+package ee.carlrobert.llm.client.ollama.completion.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class OllamaPullResponse {
+
+  private String status;
+  private String digest;
+  /**
+   * Total amount of bytes.
+   */
+  private Long total;
+  /**
+   * Downloaded amount of bytes.
+   */
+  private Long completed;
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public String getDigest() {
+    return digest;
+  }
+
+  public void setDigest(String digest) {
+    this.digest = digest;
+  }
+
+  public Long getTotal() {
+    return total;
+  }
+
+  public void setTotal(Long total) {
+    this.total = total;
+  }
+
+  public Long getCompleted() {
+    return completed;
+  }
+
+  public void setCompleted(Long completed) {
+    this.completed = completed;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaResponseFormat.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaResponseFormat.java
@@ -1,0 +1,18 @@
+package ee.carlrobert.llm.client.ollama.completion.response;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum OllamaResponseFormat {
+  JSON("json");
+
+  private final String value;
+
+  OllamaResponseFormat(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaTagsResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/ollama/completion/response/OllamaTagsResponse.java
@@ -1,0 +1,21 @@
+package ee.carlrobert.llm.client.ollama.completion.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class OllamaTagsResponse {
+
+  private List<OllamaModel> models;
+
+  public List<OllamaModel> getModels() {
+    return models;
+  }
+
+  public void setModels(List<OllamaModel> models) {
+    this.models = models;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/you/completion/YouCompletionEventListener.java
+++ b/src/main/java/ee/carlrobert/llm/client/you/completion/YouCompletionEventListener.java
@@ -3,7 +3,7 @@ package ee.carlrobert.llm.client.you.completion;
 import ee.carlrobert.llm.completion.CompletionEventListener;
 import java.util.List;
 
-public interface YouCompletionEventListener extends CompletionEventListener {
+public interface YouCompletionEventListener extends CompletionEventListener<String> {
 
   default void onSerpResults(List<YouSerpResult> results) {
   }

--- a/src/main/java/ee/carlrobert/llm/completion/CompletionEventListener.java
+++ b/src/main/java/ee/carlrobert/llm/completion/CompletionEventListener.java
@@ -2,9 +2,9 @@ package ee.carlrobert.llm.completion;
 
 import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
 
-public interface CompletionEventListener {
+public interface CompletionEventListener<T> {
 
-  default void onMessage(String message) {
+  default void onMessage(T message) {
   }
 
   default void onComplete(StringBuilder messageBuilder) {

--- a/src/main/java/ee/carlrobert/llm/completion/CompletionEventSourceListener.java
+++ b/src/main/java/ee/carlrobert/llm/completion/CompletionEventSourceListener.java
@@ -16,27 +16,27 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class CompletionEventSourceListener extends EventSourceListener {
+public abstract class CompletionEventSourceListener<T> extends EventSourceListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(CompletionEventSourceListener.class);
 
-  private final CompletionEventListener listeners;
+  private final CompletionEventListener<T> listeners;
   private final StringBuilder messageBuilder = new StringBuilder();
   private final boolean retryOnReadTimeout;
   private final Consumer<String> onRetry;
 
-  public CompletionEventSourceListener(CompletionEventListener listeners) {
+  public CompletionEventSourceListener(CompletionEventListener<T> listeners) {
     this(listeners, false, null);
   }
 
-  public CompletionEventSourceListener(CompletionEventListener listeners,
+  public CompletionEventSourceListener(CompletionEventListener<T> listeners,
       boolean retryOnReadTimeout, Consumer<String> onRetry) {
     this.listeners = listeners;
     this.retryOnReadTimeout = retryOnReadTimeout;
     this.onRetry = onRetry;
   }
 
-  protected abstract String getMessage(String data) throws JsonProcessingException;
+  protected abstract T getMessage(String data) throws JsonProcessingException;
 
   protected abstract ErrorDetails getErrorDetails(String data) throws JsonProcessingException;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,4 @@ openai.baseUrl=https://api.openai.com
 azure.openai.baseUrl=https://%s.openai.azure.com
 you.baseUrl=https://you.com
 llama.baseUrl=http://localhost:8080
+ollama.baseUrl=http://localhost:11434

--- a/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
@@ -70,7 +70,7 @@ class AzureClientTest extends BaseTest {
                 .setPresencePenalty(0.1)
                 .setFrequencyPenalty(0.1)
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onMessage(String message) {
                 resultMessageBuilder.append(message);
@@ -182,7 +182,7 @@ class AzureClientTest extends BaseTest {
                 .setFrequencyPenalty(0.1)
                 .setOverriddenPath("/v1/deployments/%s/completions?api_version=%s")
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onMessage(String message) {
                 resultMessageBuilder.append(message);
@@ -216,7 +216,7 @@ class AzureClientTest extends BaseTest {
             new OpenAIChatCompletionRequest.Builder(
                 List.of(new OpenAIChatCompletionMessage("user", "TEST_PROMPT")))
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onError(ErrorDetails error, Throwable t) {
                 errorMessageBuilder.append(error.getMessage());
@@ -245,7 +245,7 @@ class AzureClientTest extends BaseTest {
             new OpenAIChatCompletionRequest.Builder(
                 List.of(new OpenAIChatCompletionMessage("user", "TEST_PROMPT")))
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onError(ErrorDetails error, Throwable t) {
                 errorMessageBuilder.append(error.getMessage());

--- a/src/test/java/ee/carlrobert/llm/client/LlamaClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/LlamaClientTest.java
@@ -43,7 +43,7 @@ public class LlamaClientTest extends BaseTest {
             new LlamaCompletionRequest.Builder("TEST_PROMPT")
                 .setN_predict(10)
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onMessage(String message) {
                 resultMessageBuilder.append(message);
@@ -137,7 +137,7 @@ public class LlamaClientTest extends BaseTest {
                 .setStop(List.of("  <EOT>", "<EOT>")),
                 "TEST_PREFIX",
                 "TEST_SUFFIX"),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onMessage(String message) {
                 resultMessageBuilder.append(message);

--- a/src/test/java/ee/carlrobert/llm/client/OllamaClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/OllamaClientTest.java
@@ -10,7 +10,7 @@ import static org.awaitility.Awaitility.await;
 
 import ee.carlrobert.llm.client.http.ResponseEntity;
 import ee.carlrobert.llm.client.http.exchange.BasicHttpExchange;
-import ee.carlrobert.llm.client.http.exchange.StreamHttpExchange;
+import ee.carlrobert.llm.client.http.exchange.NdJsonStreamHttpExchange;
 import ee.carlrobert.llm.client.ollama.OllamaClient;
 import ee.carlrobert.llm.client.ollama.completion.request.OllamaCompletionRequest;
 import ee.carlrobert.llm.client.ollama.completion.request.OllamaCompletionRequest.Builder;
@@ -34,7 +34,7 @@ public class OllamaClientTest extends BaseTest {
     OllamaParameters options = new OllamaParameters(new OllamaParameters.Builder()
         .temperature(0.8));
 
-    expectOllama((StreamHttpExchange) request -> {
+    expectOllama((NdJsonStreamHttpExchange) request -> {
       assertThat(request.getUri().getPath()).isEqualTo("/api/generate");
       assertThat(request.getMethod()).isEqualTo("POST");
       assertThat(request.getBody())
@@ -143,7 +143,7 @@ public class OllamaClientTest extends BaseTest {
   void shouldStreamPullOllamaModel() {
     var results = new ArrayList<OllamaPullResponse>();
 
-    expectOllama((StreamHttpExchange) request -> {
+    expectOllama((NdJsonStreamHttpExchange)  request -> {
       assertThat(request.getUri().getPath()).isEqualTo("/api/pull");
       assertThat(request.getMethod()).isEqualTo("POST");
       assertThat(request.getBody())

--- a/src/test/java/ee/carlrobert/llm/client/OllamaClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/OllamaClientTest.java
@@ -1,0 +1,249 @@
+package ee.carlrobert.llm.client;
+
+import static ee.carlrobert.llm.client.util.JSONUtil.e;
+import static ee.carlrobert.llm.client.util.JSONUtil.jsonArray;
+import static ee.carlrobert.llm.client.util.JSONUtil.jsonMap;
+import static ee.carlrobert.llm.client.util.JSONUtil.jsonMapResponse;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import ee.carlrobert.llm.client.http.ResponseEntity;
+import ee.carlrobert.llm.client.http.exchange.BasicHttpExchange;
+import ee.carlrobert.llm.client.http.exchange.StreamHttpExchange;
+import ee.carlrobert.llm.client.ollama.OllamaClient;
+import ee.carlrobert.llm.client.ollama.completion.request.OllamaCompletionRequest;
+import ee.carlrobert.llm.client.ollama.completion.request.OllamaCompletionRequest.Builder;
+import ee.carlrobert.llm.client.ollama.completion.request.OllamaEmbeddingRequest;
+import ee.carlrobert.llm.client.ollama.completion.request.OllamaParameters;
+import ee.carlrobert.llm.client.ollama.completion.request.OllamaPullRequest;
+import ee.carlrobert.llm.client.ollama.completion.response.OllamaModel;
+import ee.carlrobert.llm.client.ollama.completion.response.OllamaPullResponse;
+import ee.carlrobert.llm.completion.CompletionEventListener;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class OllamaClientTest extends BaseTest {
+
+  @Test
+  void shouldStreamOllamaCompletion() {
+    var resultMessageBuilder = new StringBuilder();
+
+    OllamaParameters options = new OllamaParameters(new OllamaParameters.Builder()
+        .temperature(0.8));
+
+    expectOllama((StreamHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo("/api/generate");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getBody())
+          .extracting("model", "prompt", "options", "system", "stream")
+          .containsExactly("codellama:7b", "TEST_PROMPT", Map.of("temperature", 0.8),
+              "SYSTEM_PROMPT", true);
+      assertThat(request.getHeaders())
+          .flatExtracting("Accept", "Connection")
+          .containsExactly("text/event-stream", "Keep-Alive");
+      return List.of(
+          jsonMapResponse(e("response", "Hel"), e("done", false)),
+          jsonMapResponse(e("response", "lo"), e("done", false)),
+          jsonMapResponse(e("response", "!"), e("done", true)));
+    });
+
+    new OllamaClient.Builder()
+        .build()
+        .getChatCompletionAsync(
+            new OllamaCompletionRequest.Builder("codellama:7b",
+                "TEST_PROMPT")
+                .setSystem("SYSTEM_PROMPT")
+                .setStream(true)
+                .setOptions(options)
+                .build(),
+            new CompletionEventListener<String>() {
+              @Override
+              public void onMessage(String message) {
+                resultMessageBuilder.append(message);
+              }
+            });
+
+    await().atMost(5, SECONDS).until(() -> "Hello!".contentEquals(resultMessageBuilder));
+  }
+
+  @Test
+  void shouldGetOllamaCompletion() {
+    expectOllama((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo("/api/generate");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getBody())
+          .extracting("prompt", "stream")
+          .containsExactly("TEST_PROMPT", false);
+      return new ResponseEntity(jsonMapResponse("response", "Hello!"));
+    });
+
+    var response = new OllamaClient.Builder()
+        .build()
+        .getChatCompletion(new Builder("codellama:7b", "TEST_PROMPT")
+            .setStream(false)
+            .build());
+
+    assertThat(response.getResponse()).isEqualTo("Hello!");
+  }
+
+  @Test
+  void shouldGetOllamaTags() {
+    expectOllama((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo("/api/tags");
+      assertThat(request.getMethod()).isEqualTo("GET");
+      return new ResponseEntity(jsonMapResponse("models",
+          jsonArray(Map.of("name", "codellama:7b",
+                  "size", 70000,
+                  "details", jsonMap(e("format", "gguf"), e("parameter_size", "7B"))
+              ),
+              Map.of("name", "codellama:13b",
+                  "size", 130000,
+                  "details", jsonMap(e("format", "gguf"), e("parameter_size", "13B"))
+              )
+          )));
+    });
+
+    var response = new OllamaClient.Builder()
+        .build()
+        .getModelTags();
+
+    assertThat(response.getModels()).hasSize(2);
+    OllamaModel firstModel = response.getModels().get(0);
+    assertThat(firstModel.getName()).isEqualTo("codellama:7b");
+    assertThat(firstModel.getSize()).isEqualTo(70000);
+    assertThat(firstModel.getDetails().getParameterSize()).isEqualTo("7B");
+    OllamaModel secondModel = response.getModels().get(1);
+    assertThat(secondModel.getName()).isEqualTo("codellama:13b");
+    assertThat(secondModel.getSize()).isEqualTo(130000);
+    assertThat(secondModel.getDetails().getParameterSize()).isEqualTo("13B");
+  }
+
+  @Test
+  void shouldPullOllamaModel() {
+    expectOllama((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo("/api/pull");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getBody())
+          .extracting("name", "stream")
+          .containsExactly("codellama:7b", false);
+      return new ResponseEntity(jsonMapResponse("status", "success"));
+    });
+
+    var response = new OllamaClient.Builder()
+        .build()
+        .pullModel(new OllamaPullRequest("codellama:7b", false));
+
+    assertThat(response.getStatus()).isEqualTo("success");
+  }
+
+  @Test
+  void shouldStreamPullOllamaModel() {
+    var results = new ArrayList<OllamaPullResponse>();
+
+    expectOllama((StreamHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo("/api/pull");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getBody())
+          .extracting("name", "stream")
+          .containsExactly("codellama:7b", true);
+      return List.of(
+          jsonMapResponse(e("status", "downloading digestname"), e("digest", "digestname"),
+              e("total", "1234"), e("completed", "10")),
+          jsonMapResponse(e("status", "verifying sha256 digestname")),
+          jsonMapResponse(e("status", "writing manifest")),
+          jsonMapResponse(e("status", "removing any unused layers")),
+          jsonMapResponse(e("status", "success")));
+    });
+
+    new OllamaClient.Builder()
+        .build()
+        .pullModelAsync(new OllamaPullRequest("codellama:7b", true),
+            new CompletionEventListener<>() {
+              @Override
+              public void onMessage(OllamaPullResponse response) {
+                results.add(response);
+              }
+            });
+
+    await().atMost(5, SECONDS).until(() -> results.size() == 5);
+    OllamaPullResponse firstResponse = results.get(0);
+    assertThat(firstResponse.getStatus()).isEqualTo("downloading digestname");
+    assertThat(firstResponse.getDigest()).isEqualTo("digestname");
+    assertThat(firstResponse.getTotal()).isEqualTo(1234);
+    assertThat(firstResponse.getCompleted()).isEqualTo(10);
+    assertThat(results.get(1).getStatus()).isEqualTo("verifying sha256 digestname");
+    assertThat(results.get(2).getStatus()).isEqualTo("writing manifest");
+    assertThat(results.get(3).getStatus()).isEqualTo("removing any unused layers");
+    assertThat(results.get(4).getStatus()).isEqualTo("success");
+  }
+
+  @Test
+  void shouldDeleteOllamaModel() {
+    expectOllama((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo("/api/delete");
+      assertThat(request.getMethod()).isEqualTo("DELETE");
+      assertThat(request.getBody()).extracting("name")
+          .isEqualTo("codellama:7b");
+      return new ResponseEntity(null);
+    });
+
+    var response = new OllamaClient.Builder()
+        .build()
+        .deleteModel("codellama:7b");
+
+    assertThat(response).isTrue();
+  }
+
+  @Test
+  void shouldGetOllamaModelinfo() {
+    expectOllama((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo("/api/show");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getBody()).extracting("name")
+          .isEqualTo("codellama:7b");
+      return new ResponseEntity(jsonMapResponse(
+          e("modelfile", "# Modelfile generated by \"ollama show\"\n"),
+          e("template", "{{ .System }}\nUSER: {{ .Prompt }}\nASSSISTANT: "),
+          e("parameters", "num_ctx                        4096"),
+          e("details", jsonMap(e("format", "gguf"), e("parameter_size", "7B"))
+          )));
+    });
+
+    var response = new OllamaClient.Builder()
+        .build()
+        .getModelInfo("codellama:7b");
+
+    assertThat(response.getModelfile()).isEqualTo("# Modelfile generated by \"ollama show\"\n");
+    assertThat(response.getTemplate()).isEqualTo(
+        "{{ .System }}\nUSER: {{ .Prompt }}\nASSSISTANT: ");
+    assertThat(response.getParameters()).isEqualTo("num_ctx                        4096");
+    assertThat(response.getDetails().getFormat()).isEqualTo("gguf");
+    assertThat(response.getDetails().getParameterSize()).isEqualTo("7B");
+
+  }
+
+  @Test
+  void shouldGetOllamaEmbedding() {
+    double[] embedding = {0.1, 0.2, 0.3};
+
+    expectOllama((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo("/api/embeddings");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getBody())
+          .extracting("model", "prompt")
+          .containsExactly("codellama:7b", "This is a prompt");
+      return new ResponseEntity(jsonMapResponse(e("embedding", embedding)));
+    });
+
+    var response = new OllamaClient.Builder()
+        .build()
+        .getEmbedding(
+            new OllamaEmbeddingRequest.Builder("codellama:7b", "This is a prompt").build());
+
+    assertThat(response.getEmbedding()).isEqualTo(embedding);
+  }
+
+}

--- a/src/test/java/ee/carlrobert/llm/client/OpenAIClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/OpenAIClientTest.java
@@ -76,7 +76,7 @@ class OpenAIClientTest extends BaseTest {
                 .setPresencePenalty(0.1)
                 .setFrequencyPenalty(0.1)
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onMessage(String message) {
                 resultMessageBuilder.append(message);
@@ -132,7 +132,7 @@ class OpenAIClientTest extends BaseTest {
                 .setPresencePenalty(0.1)
                 .setFrequencyPenalty(0.1)
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onMessage(String message) {
                 resultMessageBuilder.append(message);
@@ -190,7 +190,7 @@ class OpenAIClientTest extends BaseTest {
                 .setFrequencyPenalty(0.1)
                 .setOverriddenPath("/v1/test/segment")
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onMessage(String message) {
                 resultMessageBuilder.append(message);
@@ -376,7 +376,7 @@ class OpenAIClientTest extends BaseTest {
                 List.of(new OpenAIChatCompletionMessage("user", "TEST_PROMPT")))
                 .setModel(OpenAIChatCompletionModel.GPT_3_5)
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onError(ErrorDetails error, Throwable t) {
                 assertThat(error.getCode()).isEqualTo("invalid_api_key");
@@ -405,7 +405,7 @@ class OpenAIClientTest extends BaseTest {
                 List.of(new OpenAIChatCompletionMessage("user", "TEST_PROMPT")))
                 .setModel(OpenAIChatCompletionModel.GPT_3_5)
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onError(ErrorDetails error, Throwable t) {
                 errorMessageBuilder.append(error.getMessage());

--- a/src/test/java/ee/carlrobert/llm/client/YouClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/YouClientTest.java
@@ -84,7 +84,7 @@ public class YouClientTest extends BaseTest {
                 .setUseGPT4Model(true)
                 .setQueryTraceId(queryTraceId)
                 .build(),
-            new CompletionEventListener() {
+            new CompletionEventListener<String>() {
               @Override
               public void onMessage(String message) {
                 resultMessageBuilder.append(message);

--- a/src/test/java/ee/carlrobert/llm/client/http/LocalCallbackServer.java
+++ b/src/test/java/ee/carlrobert/llm/client/http/LocalCallbackServer.java
@@ -80,12 +80,15 @@ public class LocalCallbackServer {
     exchange.getResponseHeaders().add("Content-Type", "application/json");
 
     var response = expectation.getExchange().getResponse(new RequestEntity(exchange));
-    exchange.sendResponseHeaders(response.getStatusCode(), response.getResponse().length());
-
     var responseBody = exchange.getResponseBody();
-    responseBody.write(response.getResponse().getBytes());
-    responseBody.flush();
-    responseBody.close();
+    String responseString = response.getResponse();
+    exchange.sendResponseHeaders(response.getStatusCode(),
+        responseString == null ? 0 : responseString.length());
+    if (responseString != null) {
+      responseBody.write(responseString.getBytes());
+      responseBody.flush();
+      responseBody.close();
+    }
   }
 
   private void handleStreamExchange(

--- a/src/test/java/ee/carlrobert/llm/client/http/exchange/NdJsonStreamHttpExchange.java
+++ b/src/test/java/ee/carlrobert/llm/client/http/exchange/NdJsonStreamHttpExchange.java
@@ -1,0 +1,11 @@
+package ee.carlrobert.llm.client.http.exchange;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import ee.carlrobert.llm.client.http.RequestEntity;
+import java.util.List;
+
+@FunctionalInterface
+public interface NdJsonStreamHttpExchange extends Exchange {
+
+  List<String> getResponse(RequestEntity request) throws JsonProcessingException;
+}

--- a/src/test/java/ee/carlrobert/llm/client/http/expectation/NdJsonStreamExpectation.java
+++ b/src/test/java/ee/carlrobert/llm/client/http/expectation/NdJsonStreamExpectation.java
@@ -1,0 +1,18 @@
+package ee.carlrobert.llm.client.http.expectation;
+
+import ee.carlrobert.llm.client.http.Service;
+import ee.carlrobert.llm.client.http.exchange.NdJsonStreamHttpExchange;
+
+public class NdJsonStreamExpectation extends Expectation {
+
+  private final NdJsonStreamHttpExchange exchange;
+
+  public NdJsonStreamExpectation(Service service, NdJsonStreamHttpExchange exchange) {
+    super(service);
+    this.exchange = exchange;
+  }
+
+  public NdJsonStreamHttpExchange getExchange() {
+    return exchange;
+  }
+}

--- a/src/test/java/ee/carlrobert/llm/client/mixin/ExternalService.java
+++ b/src/test/java/ee/carlrobert/llm/client/mixin/ExternalService.java
@@ -6,7 +6,8 @@ public enum ExternalService implements Service {
   OPENAI("openai.baseUrl"),
   AZURE("azure.openai.baseUrl"),
   YOU("you.baseUrl"),
-  LLAMA("llama.baseUrl");
+  LLAMA("llama.baseUrl"),
+  OLLAMA("ollama.baseUrl");
 
   private final String urlProperty;
 

--- a/src/test/java/ee/carlrobert/llm/client/mixin/ExternalServiceTestMixin.java
+++ b/src/test/java/ee/carlrobert/llm/client/mixin/ExternalServiceTestMixin.java
@@ -11,8 +11,11 @@ import static ee.carlrobert.llm.client.mixin.ExternalServiceTestMixin.Private.ex
 import ee.carlrobert.llm.client.http.LocalCallbackServer;
 import ee.carlrobert.llm.client.http.exchange.BasicHttpExchange;
 import ee.carlrobert.llm.client.http.exchange.Exchange;
+import ee.carlrobert.llm.client.http.exchange.NdJsonStreamHttpExchange;
 import ee.carlrobert.llm.client.http.exchange.StreamHttpExchange;
 import ee.carlrobert.llm.client.http.expectation.BasicExpectation;
+import ee.carlrobert.llm.client.http.expectation.Expectation;
+import ee.carlrobert.llm.client.http.expectation.NdJsonStreamExpectation;
 import ee.carlrobert.llm.client.http.expectation.StreamExpectation;
 import java.util.Arrays;
 import java.util.Map;
@@ -63,9 +66,16 @@ public interface ExternalServiceTestMixin {
   }
 
   private void addExpectation(ExternalService externalService, Exchange exchange) {
+    Expectation expectation;
+    if (exchange instanceof StreamHttpExchange) {
+      expectation = new StreamExpectation(externalService, (StreamHttpExchange) exchange);
+    } else if (exchange instanceof NdJsonStreamHttpExchange) {
+      expectation = new NdJsonStreamExpectation(externalService,
+          (NdJsonStreamHttpExchange) exchange);
+    } else {
+      expectation = new BasicExpectation(externalService, (BasicHttpExchange) exchange);
+    }
     externalServiceServerMap.get(externalService)
-        .addExpectation(exchange instanceof BasicHttpExchange
-            ? new BasicExpectation(externalService, (BasicHttpExchange) exchange)
-            : new StreamExpectation(externalService, (StreamHttpExchange) exchange));
+        .addExpectation(expectation);
   }
 }

--- a/src/test/java/ee/carlrobert/llm/client/mixin/ExternalServiceTestMixin.java
+++ b/src/test/java/ee/carlrobert/llm/client/mixin/ExternalServiceTestMixin.java
@@ -3,6 +3,7 @@ package ee.carlrobert.llm.client.mixin;
 
 import static ee.carlrobert.llm.client.mixin.ExternalService.AZURE;
 import static ee.carlrobert.llm.client.mixin.ExternalService.LLAMA;
+import static ee.carlrobert.llm.client.mixin.ExternalService.OLLAMA;
 import static ee.carlrobert.llm.client.mixin.ExternalService.OPENAI;
 import static ee.carlrobert.llm.client.mixin.ExternalService.YOU;
 import static ee.carlrobert.llm.client.mixin.ExternalServiceTestMixin.Private.externalServiceServerMap;
@@ -55,6 +56,10 @@ public interface ExternalServiceTestMixin {
 
   default void expectLlama(Exchange exchange) {
     addExpectation(LLAMA, exchange);
+  }
+
+  default void expectOllama(Exchange exchange) {
+    addExpectation(OLLAMA, exchange);
   }
 
   private void addExpectation(ExternalService externalService, Exchange exchange) {


### PR DESCRIPTION
This adds `OllamaClient` for the following API Endpoints:
* [/api/generate](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion) - Generate Completion
* [/api/tags](https://github.com/ollama/ollama/blob/main/docs/api.md#list-local-models) - List Model Tags
* [/api/pull](https://github.com/ollama/ollama/blob/main/docs/api.md#pull-a-model) - Pull/Download a Model
* [/api/delete](https://github.com/ollama/ollama/blob/main/docs/api.md#show-model-information) - Delete a Model
* [/api/show](https://github.com/ollama/ollama/blob/main/docs/api.md#show-model-information) - Get Model infos
* [/api/embeddings](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings) - Generate Embedding