### PR TITLE
Claude vision support

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,0 @@
-jdk:
-  - openjdk11

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeBase64Source.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeBase64Source.java
@@ -1,0 +1,58 @@
+package ee.carlrobert.llm.client.anthropic.completion;
+
+import com.fasterxml.jackson.annotation.*;
+
+import java.util.Base64;
+
+/**
+ * Represents a base64-encoded data source in Claude.
+ * <br>
+ * Allowed media types include the following:
+ * image/jpeg, image/png, image/gif, and image/webp
+ */
+@JsonTypeName("base64")
+public class ClaudeBase64Source extends ClaudeSource {
+    @JsonProperty("media_type")
+    private String mediaType;
+    private byte[] data;
+
+    public ClaudeBase64Source(String mediaType, byte[] data) {
+        this.mediaType = mediaType;
+        this.data = data;
+    }
+
+    public ClaudeBase64Source() {
+    }
+
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public void setMediaType(String mediaType) {
+        this.mediaType = mediaType;
+    }
+    @JsonIgnore
+    public byte[] getData() {
+        return this.data;
+    }
+    @JsonIgnore
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+
+    /**
+     * Gets the data as base64 encoded string.
+     */
+    @JsonGetter("data")
+    public String getBase64EncodedData() {
+        return Base64.getEncoder().encodeToString(this.data);
+    }
+
+    /**
+     * Sets the data. Only base64 encoded strings should be used.
+     */
+    @JsonSetter("data")
+    public void setBase64EncodedData(String base64Data) {
+        this.data = Base64.getDecoder().decode(base64Data);
+    }
+}

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeBase64Source.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeBase64Source.java
@@ -1,7 +1,10 @@
 package ee.carlrobert.llm.client.anthropic.completion;
 
-import com.fasterxml.jackson.annotation.*;
-
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.Base64;
 
 /**
@@ -12,51 +15,53 @@ import java.util.Base64;
  */
 @JsonTypeName("base64")
 public class ClaudeBase64Source extends ClaudeSource {
-    @JsonProperty("media_type")
-    private String mediaType;
-    private byte[] data;
+  @JsonProperty("media_type")
+  private String mediaType;
+  private byte[] data;
 
-    public ClaudeBase64Source(String mediaType, byte[] data) {
-        this.mediaType = mediaType;
-        this.data = data;
-    }
+  public ClaudeBase64Source(String mediaType, byte[] data) {
+    this.mediaType = mediaType;
+    this.data = data;
+  }
 
-    public ClaudeBase64Source() {
-    }
+  public ClaudeBase64Source() {
+  }
 
-    public String getMediaType() {
-        return mediaType;
-    }
+  public String getMediaType() {
+    return mediaType;
+  }
 
-    public void setMediaType(String mediaType) {
-        this.mediaType = mediaType;
-    }
-    @JsonIgnore
-    public byte[] getData() {
-        return this.data;
-    }
-    @JsonIgnore
-    public void setData(byte[] data) {
-        this.data = data;
-    }
+  public void setMediaType(String mediaType) {
+    this.mediaType = mediaType;
+  }
 
-    /**
-     * Gets the data as base64 encoded string.
-     *
-     * @return the data
-     */
-    @JsonGetter("data")
-    public String getBase64EncodedData() {
-        return Base64.getEncoder().encodeToString(this.data);
-    }
+  @JsonIgnore
+  public byte[] getData() {
+    return this.data;
+  }
 
-    /**
-     * Sets the data. Only base64 encoded strings should be used.
-     *
-     * @param base64Data base64 encoded data
-     */
-    @JsonSetter("data")
-    public void setBase64EncodedData(String base64Data) {
-        this.data = Base64.getDecoder().decode(base64Data);
-    }
+  @JsonIgnore
+  public void setData(byte[] data) {
+    this.data = data;
+  }
+
+  /**
+   * Gets the data as base64 encoded string.
+   *
+   * @return the data
+   */
+  @JsonGetter("data")
+  public String getBase64EncodedData() {
+    return Base64.getEncoder().encodeToString(this.data);
+  }
+
+  /**
+   * Sets the data. Only base64 encoded strings should be used.
+   *
+   * @param base64Data base64 encoded data
+   */
+  @JsonSetter("data")
+  public void setBase64EncodedData(String base64Data) {
+    this.data = Base64.getDecoder().decode(base64Data);
+  }
 }

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeBase64Source.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeBase64Source.java
@@ -42,6 +42,8 @@ public class ClaudeBase64Source extends ClaudeSource {
 
     /**
      * Gets the data as base64 encoded string.
+     *
+     * @return the data
      */
     @JsonGetter("data")
     public String getBase64EncodedData() {
@@ -50,6 +52,8 @@ public class ClaudeBase64Source extends ClaudeSource {
 
     /**
      * Sets the data. Only base64 encoded strings should be used.
+     *
+     * @param base64Data base64 encoded data
      */
     @JsonSetter("data")
     public void setBase64EncodedData(String base64Data) {

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeCompletionRequestMessage.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeCompletionRequestMessage.java
@@ -1,14 +1,22 @@
 package ee.carlrobert.llm.client.anthropic.completion;
 
+import java.util.Collections;
+import java.util.List;
+
 public class ClaudeCompletionRequestMessage {
 
   private String role;
-  private String content;
+  private List<ClaudeMessageContent> content;
 
   public ClaudeCompletionRequestMessage() {
   }
 
-  public ClaudeCompletionRequestMessage(String role, String content) {
+  public ClaudeCompletionRequestMessage(String role, ClaudeMessageContent content) {
+    this.role = role;
+    this.content = Collections.singletonList(content);
+  }
+
+  public ClaudeCompletionRequestMessage(String role, List<ClaudeMessageContent> content) {
     this.role = role;
     this.content = content;
   }
@@ -21,11 +29,11 @@ public class ClaudeCompletionRequestMessage {
     this.role = role;
   }
 
-  public String getContent() {
+  public List<ClaudeMessageContent> getContent() {
     return content;
   }
 
-  public void setContent(String content) {
+  public void setContent(List<ClaudeMessageContent> content) {
     this.content = content;
   }
 }

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageContent.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        property = "type")
+    use = JsonTypeInfo.Id.NAME,
+    property = "type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = ClaudeMessageTextContent.class, name = "text"),
-        @JsonSubTypes.Type(value = ClaudeMessageImageContent.class, name = "image")})
+    @JsonSubTypes.Type(value = ClaudeMessageTextContent.class, name = "text"),
+    @JsonSubTypes.Type(value = ClaudeMessageImageContent.class, name = "image")})
 public abstract class ClaudeMessageContent {
 }

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageContent.java
@@ -1,0 +1,13 @@
+package ee.carlrobert.llm.client.anthropic.completion;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ClaudeMessageTextContent.class, name = "text"),
+        @JsonSubTypes.Type(value = ClaudeMessageImageContent.class, name = "image")})
+public abstract class ClaudeMessageContent {
+}

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageImageContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageImageContent.java
@@ -1,0 +1,23 @@
+package ee.carlrobert.llm.client.anthropic.completion;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * Messages with image content are supported starting with Claude 3 models.
+ */
+@JsonTypeName("image")
+public class ClaudeMessageImageContent extends ClaudeMessageContent{
+
+  private ClaudeSource source;
+
+  public ClaudeMessageImageContent() {
+  }
+
+  public ClaudeSource getSource() {
+    return source;
+  }
+
+  public ClaudeMessageImageContent(ClaudeSource source) {
+    this.source = source;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageImageContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageImageContent.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * Messages with image content are supported starting with Claude 3 models.
  */
 @JsonTypeName("image")
-public class ClaudeMessageImageContent extends ClaudeMessageContent{
+public class ClaudeMessageImageContent extends ClaudeMessageContent {
 
   private ClaudeSource source;
 

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageTextContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageTextContent.java
@@ -1,0 +1,24 @@
+package ee.carlrobert.llm.client.anthropic.completion;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("text")
+public class ClaudeMessageTextContent extends ClaudeMessageContent {
+
+    private String text;
+
+    public ClaudeMessageTextContent() {
+    }
+
+    public ClaudeMessageTextContent(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageTextContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeMessageTextContent.java
@@ -5,20 +5,20 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("text")
 public class ClaudeMessageTextContent extends ClaudeMessageContent {
 
-    private String text;
+  private String text;
 
-    public ClaudeMessageTextContent() {
-    }
+  public ClaudeMessageTextContent() {
+  }
 
-    public ClaudeMessageTextContent(String text) {
-        this.text = text;
-    }
+  public ClaudeMessageTextContent(String text) {
+    this.text = text;
+  }
 
-    public String getText() {
-        return text;
-    }
+  public String getText() {
+    return text;
+  }
 
-    public void setText(String text) {
-        this.text = text;
-    }
+  public void setText(String text) {
+    this.text = text;
+  }
 }

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeSource.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeSource.java
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        property = "type")
+    use = JsonTypeInfo.Id.NAME,
+    property = "type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = ClaudeBase64Source.class, name = "base64")})
+    @JsonSubTypes.Type(value = ClaudeBase64Source.class, name = "base64")})
 public abstract class ClaudeSource {
 
 }

--- a/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeSource.java
+++ b/src/main/java/ee/carlrobert/llm/client/anthropic/completion/ClaudeSource.java
@@ -1,0 +1,14 @@
+package ee.carlrobert.llm.client.anthropic.completion;
+
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ClaudeBase64Source.class, name = "base64")})
+public abstract class ClaudeSource {
+
+}

--- a/src/test/java/ee/carlrobert/llm/client/ClaudeClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/ClaudeClientTest.java
@@ -11,6 +11,7 @@ import static org.awaitility.Awaitility.await;
 import ee.carlrobert.llm.client.anthropic.ClaudeClient;
 import ee.carlrobert.llm.client.anthropic.completion.ClaudeCompletionRequest;
 import ee.carlrobert.llm.client.anthropic.completion.ClaudeCompletionRequestMessage;
+import ee.carlrobert.llm.client.anthropic.completion.ClaudeMessageTextContent;
 import ee.carlrobert.llm.client.http.ResponseEntity;
 import ee.carlrobert.llm.client.http.exchange.BasicHttpExchange;
 import ee.carlrobert.llm.client.http.exchange.StreamHttpExchange;
@@ -29,7 +30,8 @@ public class ClaudeClientTest extends BaseTest {
     request.setModel("claude-3");
     request.setStream(true);
     request.setMaxTokens(500);
-    request.setMessages(List.of(new ClaudeCompletionRequestMessage("user", "USER_PROMPT")));
+    request.setMessages(List.of(
+            new ClaudeCompletionRequestMessage("user", new ClaudeMessageTextContent("USER_PROMPT"))));
     expectAnthropic((StreamHttpExchange) exchange -> {
       assertThat(exchange.getUri().getPath()).isEqualTo("/v1/messages");
       assertThat(exchange.getMethod()).isEqualTo("POST");
@@ -78,7 +80,8 @@ public class ClaudeClientTest extends BaseTest {
     request.setModel("claude-3");
     request.setStream(false);
     request.setMaxTokens(500);
-    request.setMessages(List.of(new ClaudeCompletionRequestMessage("user", "USER_PROMPT")));
+    request.setMessages(List.of(
+            new ClaudeCompletionRequestMessage("user", new ClaudeMessageTextContent("USER_PROMPT"))));
     expectAnthropic((BasicHttpExchange) exchange -> {
       assertThat(exchange.getUri().getPath()).isEqualTo("/v1/messages");
       assertThat(exchange.getMethod()).isEqualTo("POST");

--- a/src/test/java/ee/carlrobert/llm/client/ClaudeClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/ClaudeClientTest.java
@@ -16,6 +16,7 @@ import ee.carlrobert.llm.client.http.ResponseEntity;
 import ee.carlrobert.llm.client.http.exchange.BasicHttpExchange;
 import ee.carlrobert.llm.client.http.exchange.StreamHttpExchange;
 import ee.carlrobert.llm.completion.CompletionEventListener;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import okhttp3.OkHttpClient;
@@ -31,7 +32,7 @@ public class ClaudeClientTest extends BaseTest {
     request.setStream(true);
     request.setMaxTokens(500);
     request.setMessages(List.of(
-            new ClaudeCompletionRequestMessage("user", new ClaudeMessageTextContent("USER_PROMPT"))));
+        new ClaudeCompletionRequestMessage("user", new ClaudeMessageTextContent("USER_PROMPT"))));
     expectAnthropic((StreamHttpExchange) exchange -> {
       assertThat(exchange.getUri().getPath()).isEqualTo("/v1/messages");
       assertThat(exchange.getMethod()).isEqualTo("POST");
@@ -49,7 +50,9 @@ public class ClaudeClientTest extends BaseTest {
               "claude-3",
               true,
               500,
-              List.of(Map.of("role", "user", "content", "USER_PROMPT")));
+              List.of(Map.of("role", "user",
+                  "content", Collections.singletonList(
+                      Map.of("type", "text", "text", "USER_PROMPT")))));
       return List.of(
           jsonMapResponse("delta", jsonMap("text", "He")),
           jsonMapResponse("delta", jsonMap("text", "llo")),
@@ -81,7 +84,7 @@ public class ClaudeClientTest extends BaseTest {
     request.setStream(false);
     request.setMaxTokens(500);
     request.setMessages(List.of(
-            new ClaudeCompletionRequestMessage("user", new ClaudeMessageTextContent("USER_PROMPT"))));
+        new ClaudeCompletionRequestMessage("user", new ClaudeMessageTextContent("USER_PROMPT"))));
     expectAnthropic((BasicHttpExchange) exchange -> {
       assertThat(exchange.getUri().getPath()).isEqualTo("/v1/messages");
       assertThat(exchange.getMethod()).isEqualTo("POST");
@@ -106,7 +109,9 @@ public class ClaudeClientTest extends BaseTest {
               0.1,
               1,
               2,
-              List.of(Map.of("role", "user", "content", "USER_PROMPT")));
+              List.of(Map.of("role", "user",
+                  "content", Collections.singletonList(
+                      Map.of("type", "text", "text", "USER_PROMPT")))));
       return new ResponseEntity(
           jsonMapResponse(
               e("content", jsonArray(jsonMap("text", "TEST_ASSISTANT_RESPONSE"))),


### PR DESCRIPTION
This adds vision support for Claude.

Beware that this does break API compatibility due to polymorphism in message contents (which can now be either image or text for the current Claude API with Claude 3 models).

Usage is pretty straight forward and similar to the API description (https://docs.anthropic.com/claude/docs/vision):
```java
ClaudeCompletionRequest request = new ClaudeCompletionRequest();
List<ClaudeMessageContent> messageContent = new ArrayList<>();
messageContent.add(new ClaudeMessageImageContent(new ClaudeBase64Source("image/jpeg", jpegBytes)));
messageContent.add(new ClaudeMessageTextContent("What is in the image?"));

ClaudeCompletionRequestMessage message = new ClaudeCompletionRequestMessage("user", messageContent);
request.setMessages(Collections.singletonList(message));
```