### PR TITLE
OpenAI and Azure vision support

### DIFF
--- a/src/main/java/ee/carlrobert/llm/client/openai/completion/OpenAIChatCompletionModel.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/completion/OpenAIChatCompletionModel.java
@@ -10,7 +10,8 @@ public enum OpenAIChatCompletionModel implements CompletionModel {
   GPT_4("gpt-4", "GPT-4 (8k)", 8192),
   GPT_4_32k("gpt-4-32k", "GPT-4 (32k)", 32768),
   GPT_4_1106_128k("gpt-4-1106-preview", "GPT-4 Turbo (Legacy) (128k)", 128000),
-  GPT_4_0125_128k("gpt-4-0125-preview", "GPT-4 Turbo (128k)", 128000);
+  GPT_4_0125_128k("gpt-4-0125-preview", "GPT-4 Turbo (128k)", 128000),
+  GPT_4_VISION_PREVIEW("gpt-4-vision-preview", "GPT-4 Vision Preview (128k)", 128000),;
 
   private final String code;
   private final String description;

--- a/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIChatCompletionMessage.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIChatCompletionMessage.java
@@ -1,11 +1,19 @@
 package ee.carlrobert.llm.client.openai.completion.request;
 
+import java.util.Collections;
+import java.util.List;
+
 public class OpenAIChatCompletionMessage {
 
   private final String role;
-  private String content;
+  private List<OpenAIMessageContent> content;
 
-  public OpenAIChatCompletionMessage(String role, String content) {
+  public OpenAIChatCompletionMessage(String role, OpenAIMessageContent content) {
+    this.role = role;
+    this.content = Collections.singletonList(content);
+  }
+
+  public OpenAIChatCompletionMessage(String role, List<OpenAIMessageContent> content) {
     this.role = role;
     this.content = content;
   }
@@ -14,11 +22,11 @@ public class OpenAIChatCompletionMessage {
     return role;
   }
 
-  public String getContent() {
+  public List<OpenAIMessageContent> getContent() {
     return content;
   }
 
-  public void setContent(String content) {
+  public void setContent(List<OpenAIMessageContent> content) {
     this.content = content;
   }
 }

--- a/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIChatCompletionRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIChatCompletionRequest.java
@@ -1,11 +1,13 @@
 package ee.carlrobert.llm.client.openai.completion.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import ee.carlrobert.llm.client.openai.completion.OpenAIChatCompletionModel;
 import ee.carlrobert.llm.completion.CompletionRequest;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OpenAIChatCompletionRequest implements CompletionRequest {
 
   private final String model;

--- a/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIImageUrl.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIImageUrl.java
@@ -1,0 +1,91 @@
+package ee.carlrobert.llm.client.openai.completion.request;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Base64;
+
+/**
+ * Messages with image content are supported by OpenAIs Vision models.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OpenAIImageUrl {
+
+  private String url;
+
+  private ImageDetail detail;
+
+  public OpenAIImageUrl(String mediaType, byte[] imageData, ImageDetail detail) {
+    this.setImageUrl(mediaType, imageData);
+    this.detail = detail;
+  }
+
+  public OpenAIImageUrl(String mediaType, byte[] imageData) {
+    this.setImageUrl(mediaType, imageData);
+  }
+
+  public OpenAIImageUrl(String imageUrl, ImageDetail detail) {
+    this.url = imageUrl;
+    this.detail = detail;
+  }
+
+  public OpenAIImageUrl(String imageUrl) {
+    this.url = imageUrl;
+  }
+
+  public OpenAIImageUrl() {
+  }
+
+  public ImageDetail getDetail() {
+    return detail;
+  }
+
+  public void setDetail(ImageDetail detail) {
+    this.detail = detail;
+  }
+
+
+  public String getUrl() {
+    return url;
+  }
+
+  /**
+   * Sets the URL for the image.
+   * This can be any publicly accessible URL.
+   *
+   * @param url URL to the image
+   */
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  /**
+   * Sets the url in a way so that data is directly uploaded to OpenAI.
+   *
+   * @param mediaType media type of the image (e.g. "image/jpeg")
+   * @param imageData byte data of the image
+   */
+  @JsonIgnore
+  public void setImageUrl(String mediaType, byte[] imageData) {
+    this.url = "data:" + mediaType + ";base64,"
+            + Base64.getEncoder().encodeToString(imageData);
+  }
+
+  public enum ImageDetail {
+    HIGH("high"),
+    LOW("low"),
+    @JsonEnumDefaultValue
+    AUTO("auto");
+    private final String detail;
+
+    ImageDetail(String detail) {
+      this.detail = detail;
+    }
+
+    @JsonValue
+    public String getDetail() {
+      return this.detail;
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIMessageContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIMessageContent.java
@@ -1,0 +1,13 @@
+package ee.carlrobert.llm.client.openai.completion.request;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = OpenAIMessageTextContent.class, name = "text"),
+    @JsonSubTypes.Type(value = OpenAIMessageImageURLContent.class, name = "image_url")})
+public abstract class OpenAIMessageContent {
+}

--- a/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIMessageImageURLContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIMessageImageURLContent.java
@@ -1,0 +1,32 @@
+package ee.carlrobert.llm.client.openai.completion.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * Messages with image content are supported by OpenAIs vision models.
+ */
+@JsonTypeName("image_url")
+public class OpenAIMessageImageURLContent extends OpenAIMessageContent {
+
+
+  @JsonProperty("image_url")
+  private OpenAIImageUrl imageUrl;
+
+
+  public OpenAIMessageImageURLContent() {
+  }
+
+  public OpenAIMessageImageURLContent(OpenAIImageUrl imageUrl) {
+    this.imageUrl = imageUrl;
+  }
+
+
+  public OpenAIImageUrl getImageUrl() {
+    return imageUrl;
+  }
+
+  public void setImageUrl(OpenAIImageUrl imageUrl) {
+    this.imageUrl = imageUrl;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIMessageTextContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/completion/request/OpenAIMessageTextContent.java
@@ -1,0 +1,24 @@
+package ee.carlrobert.llm.client.openai.completion.request;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("text")
+public class OpenAIMessageTextContent extends OpenAIMessageContent {
+
+  private String text;
+
+  public OpenAIMessageTextContent() {
+  }
+
+  public OpenAIMessageTextContent(String text) {
+    this.text = text;
+  }
+
+  public String getText() {
+    return text;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+}

--- a/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
@@ -18,7 +18,10 @@ import ee.carlrobert.llm.client.http.exchange.StreamHttpExchange;
 import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
 import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionMessage;
 import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionRequest;
+import ee.carlrobert.llm.client.openai.completion.request.OpenAIMessageTextContent;
 import ee.carlrobert.llm.completion.CompletionEventListener;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import okhttp3.sse.EventSource;
@@ -52,7 +55,7 @@ class AzureClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", prompt)));
+              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))));
       return List.of(
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("role", "assistant")))),
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("content", "Hello")))),
@@ -65,7 +68,7 @@ class AzureClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", prompt)))
+                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
                 .setMaxTokens(500)
                 .setTemperature(0.5)
                 .setPresencePenalty(0.1)
@@ -109,7 +112,7 @@ class AzureClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", prompt)));
+              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))));
       return new ResponseEntity(new ObjectMapper().writeValueAsString(
           Map.of("choices", List.of(Map.of("message", Map.of(
               "role", "assistant",
@@ -122,7 +125,7 @@ class AzureClientTest extends BaseTest {
         .setActiveDirectoryAuthentication(true)
         .build()
         .getChatCompletion(new OpenAIChatCompletionRequest.Builder(
-            List.of(new OpenAIChatCompletionMessage("user", prompt)))
+            List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
             .setMaxTokens(500)
             .setTemperature(0.5)
             .setPresencePenalty(0.1)
@@ -163,7 +166,7 @@ class AzureClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", prompt)));
+              List.of(Map.of("role", "user", "content",  Collections.singletonList(Map.of("type", "text", "text", prompt)))));
       return List.of(
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("role", "assistant")))),
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("content", "Hello")))),
@@ -176,7 +179,7 @@ class AzureClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", prompt)))
+                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
                 .setMaxTokens(500)
                 .setTemperature(0.5)
                 .setPresencePenalty(0.1)
@@ -215,7 +218,7 @@ class AzureClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", "TEST_PROMPT")))
+                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent("TEST_PROMPT"))))
                 .build(),
             new CompletionEventListener<String>() {
               @Override
@@ -244,7 +247,7 @@ class AzureClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", "TEST_PROMPT")))
+                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent("TEST_PROMPT"))))
                 .build(),
             new CompletionEventListener<String>() {
               @Override

--- a/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
@@ -20,7 +20,6 @@ import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionMe
 import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionRequest;
 import ee.carlrobert.llm.client.openai.completion.request.OpenAIMessageTextContent;
 import ee.carlrobert.llm.completion.CompletionEventListener;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +54,8 @@ class AzureClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))));
+              List.of(Map.of("role", "user", "content",
+                      Collections.singletonList(Map.of("type", "text", "text", prompt)))));
       return List.of(
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("role", "assistant")))),
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("content", "Hello")))),
@@ -63,12 +63,17 @@ class AzureClientTest extends BaseTest {
     });
 
     new AzureClient.Builder("TEST_API_KEY",
-        new AzureCompletionRequestParams("TEST_RESOURCE", "TEST_DEPLOYMENT_ID", "TEST_API_VERSION"))
+        new AzureCompletionRequestParams(
+                "TEST_RESOURCE",
+                "TEST_DEPLOYMENT_ID",
+                "TEST_API_VERSION"))
         .setActiveDirectoryAuthentication(true)
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
+                List.of(new OpenAIChatCompletionMessage(
+                        "user",
+                        new OpenAIMessageTextContent(prompt))))
                 .setMaxTokens(500)
                 .setTemperature(0.5)
                 .setPresencePenalty(0.1)
@@ -112,7 +117,8 @@ class AzureClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))));
+              List.of(Map.of("role", "user", "content",
+                      Collections.singletonList(Map.of("type", "text", "text", prompt)))));
       return new ResponseEntity(new ObjectMapper().writeValueAsString(
           Map.of("choices", List.of(Map.of("message", Map.of(
               "role", "assistant",
@@ -166,7 +172,8 @@ class AzureClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content",  Collections.singletonList(Map.of("type", "text", "text", prompt)))));
+              List.of(Map.of("role", "user", "content",
+                      Collections.singletonList(Map.of("type", "text", "text", prompt)))));
       return List.of(
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("role", "assistant")))),
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("content", "Hello")))),
@@ -174,12 +181,17 @@ class AzureClientTest extends BaseTest {
     });
 
     new AzureClient.Builder("TEST_API_KEY",
-        new AzureCompletionRequestParams("TEST_RESOURCE", "TEST_DEPLOYMENT_ID", "TEST_API_VERSION"))
+        new AzureCompletionRequestParams(
+                "TEST_RESOURCE",
+                "TEST_DEPLOYMENT_ID",
+                "TEST_API_VERSION"))
         .setActiveDirectoryAuthentication(true)
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
+                List.of(new OpenAIChatCompletionMessage(
+                        "user",
+                        new OpenAIMessageTextContent(prompt))))
                 .setMaxTokens(500)
                 .setTemperature(0.5)
                 .setPresencePenalty(0.1)
@@ -214,11 +226,16 @@ class AzureClientTest extends BaseTest {
     });
 
     new AzureClient.Builder("TEST_API_KEY",
-        new AzureCompletionRequestParams("TEST_RESOURCE", "TEST_DEPLOYMENT_ID", "TEST_API_VERSION"))
+        new AzureCompletionRequestParams(
+                "TEST_RESOURCE",
+                "TEST_DEPLOYMENT_ID",
+                "TEST_API_VERSION"))
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent("TEST_PROMPT"))))
+                List.of(new OpenAIChatCompletionMessage(
+                        "user",
+                        new OpenAIMessageTextContent("TEST_PROMPT"))))
                 .build(),
             new CompletionEventListener<String>() {
               @Override
@@ -243,11 +260,16 @@ class AzureClientTest extends BaseTest {
     });
 
     new AzureClient.Builder("TEST_API_KEY",
-        new AzureCompletionRequestParams("TEST_RESOURCE", "TEST_DEPLOYMENT_ID", "TEST_API_VERSION"))
+        new AzureCompletionRequestParams(
+                "TEST_RESOURCE",
+                "TEST_DEPLOYMENT_ID",
+                "TEST_API_VERSION"))
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent("TEST_PROMPT"))))
+                List.of(new OpenAIChatCompletionMessage(
+                        "user",
+                        new OpenAIMessageTextContent("TEST_PROMPT"))))
                 .build(),
             new CompletionEventListener<String>() {
               @Override

--- a/src/test/java/ee/carlrobert/llm/client/OpenAIClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/OpenAIClientTest.java
@@ -16,13 +16,10 @@ import ee.carlrobert.llm.client.http.exchange.StreamHttpExchange;
 import ee.carlrobert.llm.client.openai.OpenAIClient;
 import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
 import ee.carlrobert.llm.client.openai.completion.OpenAIChatCompletionModel;
-import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionMessage;
-import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionRequest;
-import ee.carlrobert.llm.client.openai.completion.request.OpenAITextCompletionRequest;
-import ee.carlrobert.llm.client.openai.completion.request.Tool;
-import ee.carlrobert.llm.client.openai.completion.request.ToolFunction;
-import ee.carlrobert.llm.client.openai.completion.request.ToolFunctionParameters;
+import ee.carlrobert.llm.client.openai.completion.request.*;
 import ee.carlrobert.llm.completion.CompletionEventListener;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import okhttp3.sse.EventSource;
@@ -58,7 +55,7 @@ class OpenAIClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", prompt)));
+              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))));
       return List.of(
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("role", "assistant")))),
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("content", "Hello")))),
@@ -70,7 +67,7 @@ class OpenAIClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", prompt)))
+                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
                 .setModel(OpenAIChatCompletionModel.GPT_3_5)
                 .setMaxTokens(500)
                 .setTemperature(0.5)
@@ -171,7 +168,7 @@ class OpenAIClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", prompt)));
+              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))));
       return List.of(
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("role", "assistant")))),
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("content", "Hello")))),
@@ -183,7 +180,7 @@ class OpenAIClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", prompt)))
+                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
                 .setModel(OpenAIChatCompletionModel.GPT_3_5)
                 .setMaxTokens(500)
                 .setTemperature(0.5)
@@ -228,7 +225,7 @@ class OpenAIClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", prompt)));
+              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))));
 
       return new ResponseEntity(new ObjectMapper().writeValueAsString(Map.of("choices", List.of(
           Map.of("message", Map.of(
@@ -240,7 +237,7 @@ class OpenAIClientTest extends BaseTest {
         .setOrganization("TEST_ORGANIZATION")
         .build()
         .getChatCompletion(new OpenAIChatCompletionRequest.Builder(
-            List.of(new OpenAIChatCompletionMessage("user", prompt)))
+            List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
             .setModel(OpenAIChatCompletionModel.GPT_3_5)
             .setMaxTokens(500)
             .setTemperature(0.5)
@@ -284,7 +281,7 @@ class OpenAIClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", prompt)),
+              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))),
               List.of(Map.of("type", "function", "function",
                   Map.of(
                       "name", "get_current_weather",
@@ -336,7 +333,7 @@ class OpenAIClientTest extends BaseTest {
         .setOrganization("TEST_ORGANIZATION")
         .build()
         .getChatCompletion(new OpenAIChatCompletionRequest.Builder(
-            List.of(new OpenAIChatCompletionMessage("user", prompt)))
+            List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
             .setModel(OpenAIChatCompletionModel.GPT_3_5)
             .setMaxTokens(500)
             .setTemperature(0.5)
@@ -374,7 +371,7 @@ class OpenAIClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", "TEST_PROMPT")))
+                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent("TEST_PROMPT"))))
                 .setModel(OpenAIChatCompletionModel.GPT_3_5)
                 .build(),
             new CompletionEventListener<String>() {
@@ -403,7 +400,7 @@ class OpenAIClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", "TEST_PROMPT")))
+                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent("TEST_PROMPT"))))
                 .setModel(OpenAIChatCompletionModel.GPT_3_5)
                 .build(),
             new CompletionEventListener<String>() {

--- a/src/test/java/ee/carlrobert/llm/client/OpenAIClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/OpenAIClientTest.java
@@ -16,9 +16,14 @@ import ee.carlrobert.llm.client.http.exchange.StreamHttpExchange;
 import ee.carlrobert.llm.client.openai.OpenAIClient;
 import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
 import ee.carlrobert.llm.client.openai.completion.OpenAIChatCompletionModel;
-import ee.carlrobert.llm.client.openai.completion.request.*;
+import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionMessage;
+import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionRequest;
+import ee.carlrobert.llm.client.openai.completion.request.OpenAIMessageTextContent;
+import ee.carlrobert.llm.client.openai.completion.request.OpenAITextCompletionRequest;
+import ee.carlrobert.llm.client.openai.completion.request.Tool;
+import ee.carlrobert.llm.client.openai.completion.request.ToolFunction;
+import ee.carlrobert.llm.client.openai.completion.request.ToolFunctionParameters;
 import ee.carlrobert.llm.completion.CompletionEventListener;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +60,10 @@ class OpenAIClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))));
+              List.of(Map.of("role", "user",
+                      "content", Collections.singletonList(Map.of(
+                              "type", "text",
+                              "text", prompt)))));
       return List.of(
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("role", "assistant")))),
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("content", "Hello")))),
@@ -67,7 +75,9 @@ class OpenAIClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
+                List.of(new OpenAIChatCompletionMessage(
+                        "user",
+                        new OpenAIMessageTextContent(prompt))))
                 .setModel(OpenAIChatCompletionModel.GPT_3_5)
                 .setMaxTokens(500)
                 .setTemperature(0.5)
@@ -168,7 +178,10 @@ class OpenAIClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))));
+              List.of(Map.of("role", "user",
+                      "content", Collections.singletonList(Map.of(
+                              "type", "text",
+                              "text", prompt)))));
       return List.of(
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("role", "assistant")))),
           jsonMapResponse("choices", jsonArray(jsonMap("delta", jsonMap("content", "Hello")))),
@@ -180,7 +193,8 @@ class OpenAIClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent(prompt))))
+                List.of(new OpenAIChatCompletionMessage(
+                        "user", new OpenAIMessageTextContent(prompt))))
                 .setModel(OpenAIChatCompletionModel.GPT_3_5)
                 .setMaxTokens(500)
                 .setTemperature(0.5)
@@ -225,7 +239,10 @@ class OpenAIClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))));
+              List.of(Map.of("role", "user",
+                      "content", Collections.singletonList(Map.of(
+                              "type", "text",
+                              "text", prompt)))));
 
       return new ResponseEntity(new ObjectMapper().writeValueAsString(Map.of("choices", List.of(
           Map.of("message", Map.of(
@@ -281,7 +298,10 @@ class OpenAIClientTest extends BaseTest {
               500,
               0.1,
               0.1,
-              List.of(Map.of("role", "user", "content", Collections.singletonList(Map.of("type", "text", "text", prompt)))),
+              List.of(Map.of("role", "user",
+                      "content", Collections.singletonList(Map.of(
+                              "type", "text",
+                              "text", prompt)))),
               List.of(Map.of("type", "function", "function",
                   Map.of(
                       "name", "get_current_weather",
@@ -371,7 +391,9 @@ class OpenAIClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent("TEST_PROMPT"))))
+                List.of(new OpenAIChatCompletionMessage(
+                        "user",
+                        new OpenAIMessageTextContent("TEST_PROMPT"))))
                 .setModel(OpenAIChatCompletionModel.GPT_3_5)
                 .build(),
             new CompletionEventListener<String>() {
@@ -400,7 +422,8 @@ class OpenAIClientTest extends BaseTest {
         .build()
         .getChatCompletionAsync(
             new OpenAIChatCompletionRequest.Builder(
-                List.of(new OpenAIChatCompletionMessage("user", new OpenAIMessageTextContent("TEST_PROMPT"))))
+                List.of(new OpenAIChatCompletionMessage(
+                        "user", new OpenAIMessageTextContent("TEST_PROMPT"))))
                 .setModel(OpenAIChatCompletionModel.GPT_3_5)
                 .build(),
             new CompletionEventListener<String>() {


### PR DESCRIPTION
This is pretty similar to "Claude vision support" #17

Similar to the Claude PR, this does break API compatibility due to polymorphism in message contents (which can now be either image or text).

API reference: https://platform.openai.com/docs/guides/vision

```java
// Vision will only work with OpenAIChatCompletionModel.GPT_4_VISION_PREVIEW currently

List<OpenAIMessageContent> content = new ArrayList<>();

content.add(new OpenAIMessageImageURLContent(new OpenAIImageUrl("https://picsum.photos/200")));
// Or use a local image: new OpenAIImageUrl("image/jpeg", Files.readAllBytes(Paths.get("/path/to/local/image.jpg")))

content.add(new OpenAIMessageTextContent("What can you see in this picture?"));

OpenAIChatCompletionMessage message = new OpenAIChatCompletionMessage("user", content);
```