### PR TITLE
chore(deps): Update and centralize dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -28,9 +28,9 @@ jobs:
 
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     `maven-publish`
     signing
     checkstyle
-    id("io.github.gradle-nexus.publish-plugin") version ("1.1.0")
+    alias(libs.plugins.publish.plugin)
 }
 
 group = "ee.carlrobert"
@@ -21,24 +21,27 @@ java {
 }
 
 checkstyle {
-    toolVersion = "10.12.5"
+    toolVersion = libs.versions.checkstyle.get()
 }
 
 dependencies {
-    api("com.squareup.okhttp3:okhttp:4.10.0")
-    api("com.squareup.okhttp3:okhttp-sse:4.10.0")
-    api("com.squareup.okhttp3:logging-interceptor:4.11.0")
+    api(enforcedPlatform(libs.okhttp.bom))
+    api("com.squareup.okhttp3:okhttp")
+    api("com.squareup.okhttp3:okhttp-sse")
+    api("com.squareup.okhttp3:logging-interceptor")
 
-    implementation("org.slf4j:slf4j-api:2.0.7")
-    implementation("org.slf4j:slf4j-simple:2.0.7")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.14.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.2")
+    implementation(enforcedPlatform(libs.slf4j.bom))
+    implementation("org.slf4j:slf4j-api")
+    implementation("org.slf4j:slf4j-simple")
+    implementation(enforcedPlatform(libs.jackson.bom))
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
-    testImplementation(platform("org.junit:junit-bom:5.9.3"))
+    testImplementation(enforcedPlatform(libs.junit.bom))
     testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("commons-io:commons-io:2.11.0")
-    testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("org.awaitility:awaitility:4.2.0")
+    testImplementation(libs.commons.io)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.awaitility)
 }
 
 nexusPublishing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,22 @@
+[versions]
+assertj = "3.25.3"
+awaitility = "4.2.1"
+checkstyle = "10.15.0"
+commons-io = "2.16.0"
+jackson = "2.17.0"
+junit = "5.10.2"
+okhttp = "5.0.0-alpha.12"
+publish-plugin = "2.0.0"
+slf4j = "2.0.12"
+
+[libraries]
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
+commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
+slf4j-bom = { module = "org.slf4j:slf4j-bom", version.ref = "slf4j" }
+
+[plugins]
+publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publish-plugin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \


### PR DESCRIPTION
* Update assertj to 3.25.3
* Update awaitility to 4.2.1
* Update checkstyle to 10.15.0
* Update commons-io to 2.16.0
* Update gradle to 8.7
* Update jackson to 2.17.0
* Update junit to 5.10.2
* Update okhttp to 4.12.0
* Update slf4j to 2.0.12
* Use BOMs where possible
* Centralize dependencies in version catalog
* Allow Dependabot to update dependencies and GitHub Actions