### PR TITLE
feat: Run trivy security checks after build

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,6 +21,16 @@ jobs:
       - name: Build with Gradle
         # Build and dry-run maven-publish (metadata and pom, but no signing)
         run: ./gradlew build generateMetadataFileForMavenJavaPublication generatePomFileForMavenJavaPublication --no-daemon
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          ignore-unfixed: true
+          scan-ref: 'build/publications/mavenJava'
+          scan-type: 'fs'
+          scanners: 'vuln'
+          severity: 'MEDIUM,HIGH,CRITICAL'
+        env:
+          TRIVY_FILE_PATTERNS: "pom:pom.*.xml"
 
   publish:
     name: Publish Artifacts


### PR DESCRIPTION
When a new PR would introduce vulnerabilities, for example through old transitive dependencies, the pipeline would fail and the PR could not be merged until all vulnerabilities have been fixed (by upgrading, excluding or overriding dependency versions).