### PR TITLE
feat: add Google API for Gemini models

### DIFF
--- a/src/main/java/ee/carlrobert/llm/client/google/GoogleClient.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/GoogleClient.java
@@ -1,0 +1,320 @@
+package ee.carlrobert.llm.client.google;
+
+import static ee.carlrobert.llm.client.DeserializationUtil.OBJECT_MAPPER;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import ee.carlrobert.llm.PropertiesLoader;
+import ee.carlrobert.llm.client.DeserializationUtil;
+import ee.carlrobert.llm.client.google.completion.ApiResponseError;
+import ee.carlrobert.llm.client.google.completion.GoogleCompletionContent;
+import ee.carlrobert.llm.client.google.completion.GoogleCompletionRequest;
+import ee.carlrobert.llm.client.google.completion.GoogleCompletionResponse;
+import ee.carlrobert.llm.client.google.completion.GoogleCompletionResponse.Candidate;
+import ee.carlrobert.llm.client.google.completion.GoogleContentPart;
+import ee.carlrobert.llm.client.google.embedding.ContentEmbedding;
+import ee.carlrobert.llm.client.google.embedding.GoogleBatchEmbeddingResponse;
+import ee.carlrobert.llm.client.google.embedding.GoogleEmbeddingContentRequest;
+import ee.carlrobert.llm.client.google.embedding.GoogleEmbeddingRequest;
+import ee.carlrobert.llm.client.google.embedding.GoogleEmbeddingResponse;
+import ee.carlrobert.llm.client.google.models.GoogleModel;
+import ee.carlrobert.llm.client.google.models.GoogleModelsResponse;
+import ee.carlrobert.llm.client.google.models.GoogleModelsResponse.GeminiModelDetails;
+import ee.carlrobert.llm.client.google.models.GoogleTokensResponse;
+import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
+import ee.carlrobert.llm.completion.CompletionEventListener;
+import ee.carlrobert.llm.completion.CompletionEventSourceListener;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.sse.EventSource;
+import okhttp3.sse.EventSources;
+
+public class GoogleClient {
+
+  private static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
+
+  private final OkHttpClient httpClient;
+  private final String host;
+  private final String apiKey;
+
+  protected GoogleClient(Builder builder, OkHttpClient.Builder httpClientBuilder) {
+    this.httpClient = httpClientBuilder.build();
+    this.host = builder.host;
+    this.apiKey = builder.apiKey;
+  }
+
+  public EventSource getChatCompletionAsync(
+      GoogleCompletionRequest request,
+      GoogleModel model,
+      CompletionEventListener<String> eventListener) {
+    return getChatCompletionAsync(request, model.getCode(), eventListener);
+  }
+
+  public EventSource getChatCompletionAsync(
+      GoogleCompletionRequest request,
+      String model,
+      CompletionEventListener<String> eventListener) {
+    return EventSources.createFactory(httpClient)
+        .newEventSource(buildPostRequest(request, model, "streamGenerateContent", true),
+            getEventSourceListener(eventListener));
+  }
+
+  /**
+   * <a
+   * href="https://ai.google.dev/api/rest/v1/models/generateContent?authuser=1">GenerateContent</a>.
+   */
+  public GoogleCompletionResponse getChatCompletion(GoogleCompletionRequest request,
+      GoogleModel model) {
+    return getChatCompletion(request, model.getCode());
+  }
+
+  /**
+   * <a
+   * href="https://ai.google.dev/api/rest/v1/models/generateContent?authuser=1">GenerateContent</a>.
+   */
+  public GoogleCompletionResponse getChatCompletion(GoogleCompletionRequest request, String model) {
+    try (var response = httpClient.newCall(
+        buildPostRequest(request, model, "generateContent", false)).execute()) {
+      return DeserializationUtil.mapResponse(response, GoogleCompletionResponse.class);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Could not get llama completion for the given request:\n" + request, e);
+    }
+  }
+
+  public double[] getEmbedding(String text, GoogleModel model) {
+    return getEmbedding(List.of(text), model.getCode());
+  }
+
+  public double[] getEmbedding(String text, String model) {
+    return getEmbedding(List.of(text), model);
+  }
+
+  public double[] getEmbedding(List<String> texts, GoogleModel model) {
+    return getEmbedding(texts, model.getCode());
+  }
+
+  public double[] getEmbedding(List<String> texts, String model) {
+    return getEmbedding(new GoogleEmbeddingRequest.Builder(new GoogleCompletionContent(texts))
+        .build(), model);
+  }
+
+  /**
+   * <a href="https://ai.google.dev/api/rest/v1/models/embedContent?authuser=1">EmbedContent</a>.
+   */
+  public double[] getEmbedding(GoogleEmbeddingRequest request, GoogleModel model) {
+    return getEmbedding(request, model.getCode());
+  }
+
+  /**
+   * <a href="https://ai.google.dev/api/rest/v1/models/embedContent?authuser=1">EmbedContent</a>.
+   */
+  public double[] getEmbedding(GoogleEmbeddingRequest request, String model) {
+    try (var response = httpClient
+        .newCall(buildPostRequest(request, model, "embedContent", false))
+        .execute()) {
+
+      return Optional.ofNullable(
+              DeserializationUtil.mapResponse(response, GoogleEmbeddingResponse.class))
+          .map(GoogleEmbeddingResponse::getEmbedding)
+          .map(ContentEmbedding::getValues)
+          .orElse(null);
+
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to fetch embedding", e);
+    }
+  }
+
+  /**
+   * <a
+   * href="https://ai.google.dev/api/rest/v1/models/batchEmbedContents?authuser=1">BatchEmbedContents</a>.
+   */
+  public List<double[]> getBatchEmbeddings(
+      List<GoogleEmbeddingContentRequest> requests,
+      GoogleModel model) {
+    return getBatchEmbeddings(requests, model.getCode());
+  }
+
+  public List<double[]> getBatchEmbeddings(
+      List<GoogleEmbeddingContentRequest> requests,
+      String model) {
+    try (var response = httpClient
+        .newCall(buildPostRequest(Map.of("requests", requests), model, "batchEmbedContents", false))
+        .execute()) {
+
+      var embeddings = Optional.ofNullable(
+              DeserializationUtil.mapResponse(response, GoogleBatchEmbeddingResponse.class))
+          .map(GoogleBatchEmbeddingResponse::getEmbeddings)
+          .stream()
+          .flatMap(Collection::stream)
+          .filter(Objects::nonNull)
+          .map(ContentEmbedding::getValues)
+          .filter(Objects::nonNull)
+          .collect(toList());
+      return embeddings.isEmpty() ? null : embeddings;
+
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to fetch embedding", e);
+    }
+  }
+
+
+  /**
+   * <a href="https://ai.google.dev/api/rest/v1/models/list?authuser=1">Models List</a>.
+   */
+  public GoogleModelsResponse getModels(Integer pageSize, String pageToken) {
+    String url = host + "/v1/models";
+    HttpUrl.Builder urlBuilder = HttpUrl.parse(url).newBuilder();
+    if (pageSize != null) {
+      urlBuilder.addQueryParameter("pageSize", pageSize.toString());
+    }
+    if (pageToken != null) {
+      urlBuilder.addQueryParameter("pageToken", pageToken);
+    }
+    try (var response = httpClient
+        .newCall(defaultRequestBuilder(urlBuilder, false).get().build())
+        .execute()) {
+      return DeserializationUtil.mapResponse(response, GoogleModelsResponse.class);
+
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to fetch models", e);
+    }
+  }
+
+  /**
+   * <a href="https://ai.google.dev/api/rest/v1/models/get?authuser=1">Get Model</a>.
+   */
+  public GeminiModelDetails getModel(String name) {
+    String url = host + "/v1/models/" + name;
+    try (var response = httpClient.newCall(defaultRequestBuilder(url, false).get().build())
+        .execute()) {
+      return DeserializationUtil.mapResponse(response, GeminiModelDetails.class);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to fetch model", e);
+    }
+  }
+
+  /**
+   * <a href="https://ai.google.dev/api/rest/v1/models/countTokens?authuser=1">CountTokens</a>.
+   */
+  public GoogleTokensResponse getCountTokens(List<GoogleCompletionContent> contents,
+      GoogleModel model) {
+    return getCountTokens(contents, model.getCode());
+  }
+
+  /**
+   * <a href="https://ai.google.dev/api/rest/v1/models/countTokens?authuser=1">CountTokens</a>.
+   */
+  public GoogleTokensResponse getCountTokens(List<GoogleCompletionContent> contents, String model) {
+    try (var response = httpClient
+        .newCall(buildPostRequest(Map.of("contents", contents), model, "countTokens", false))
+        .execute()) {
+      return DeserializationUtil.mapResponse(response, GoogleTokensResponse.class);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to fetch tokens count", e);
+    }
+  }
+
+  private Request buildPostRequest(Object request, String model, String path,
+      boolean stream) {
+    try {
+      Request.Builder builder = defaultRequestBuilder(
+          host + format("/v1/models/%s:%s", model, path), stream)
+          .post(RequestBody.create(OBJECT_MAPPER.writeValueAsString(request), APPLICATION_JSON));
+      return builder.build();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Request.Builder defaultRequestBuilder(String url, boolean stream) {
+    return defaultRequestBuilder(HttpUrl.parse(url).newBuilder(), stream);
+  }
+
+  private Request.Builder defaultRequestBuilder(HttpUrl.Builder url, boolean stream) {
+    if (apiKey != null && !apiKey.isEmpty()) {
+      url.addQueryParameter("key", apiKey);
+    }
+    // see https://ai.google.dev/gemini-api/docs/get-started/rest#stream_generate_content
+    if (stream) {
+      url.addQueryParameter("alt", "sse");
+    }
+    return new Request.Builder()
+        .url(url.build())
+        .header("Cache-Control", "no-cache")
+        .header("Content-Type", "application/json")
+        .header("Accept", stream ? "text/event-stream" : "text/json");
+  }
+
+  private CompletionEventSourceListener<String> getEventSourceListener(
+      CompletionEventListener<String> eventListener) {
+    return new CompletionEventSourceListener<>(eventListener) {
+      @Override
+      protected String getMessage(String data) {
+        try {
+          var candidates = OBJECT_MAPPER.readValue(data, GoogleCompletionResponse.class)
+              .getCandidates();
+          return (candidates == null ? Stream.<Candidate>empty() : candidates.stream())
+              .filter(Objects::nonNull)
+              .flatMap(candidate -> candidate.getContent().getParts().stream())
+              .filter(Objects::nonNull)
+              .findFirst()
+              .map(GoogleContentPart::getText)
+              .orElse("");
+        } catch (JacksonException e) {
+          // ignore
+          System.out.println();
+        }
+        return "";
+      }
+
+      @Override
+      protected ErrorDetails getErrorDetails(String data) throws JsonProcessingException {
+        var googleError = OBJECT_MAPPER.readValue(data, ApiResponseError.class).getError();
+        return googleError == null ? null
+            : new ErrorDetails(googleError.getMessage(), googleError.getStatus(), null,
+                googleError.getCode());
+      }
+    };
+  }
+
+  public static class Builder {
+
+    private String host = PropertiesLoader.getValue("google.baseUrl");
+    private String apiKey;
+
+    public Builder(String apiKey) {
+      this.apiKey = apiKey;
+    }
+
+    public Builder setHost(String host) {
+      this.host = host;
+      return this;
+    }
+
+    public Builder setApiKey(String apiKey) {
+      this.apiKey = apiKey;
+      return this;
+    }
+
+    public GoogleClient build(OkHttpClient.Builder builder) {
+      return new GoogleClient(this, builder);
+    }
+
+    public GoogleClient build() {
+      return build(new OkHttpClient.Builder());
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/ApiResponseError.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/ApiResponseError.java
@@ -1,0 +1,20 @@
+package ee.carlrobert.llm.client.google.completion;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiResponseError  {
+
+  private final ErrorDetails error;
+
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+  public ApiResponseError(@JsonProperty("error") ErrorDetails error) {
+    this.error = error;
+  }
+
+  public ErrorDetails getError() {
+    return error;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/ErrorDetails.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/ErrorDetails.java
@@ -1,0 +1,51 @@
+package ee.carlrobert.llm.client.google.completion;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import ee.carlrobert.llm.client.BaseError;
+import java.util.StringJoiner;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ErrorDetails extends BaseError {
+
+  private final String message;
+  private final String status;
+  private final String code;
+
+  public ErrorDetails(String message) {
+    this(message, null, null);
+  }
+
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+  public ErrorDetails(
+      @JsonProperty("message") String message,
+      @JsonProperty("status") String status,
+      @JsonProperty("code") String code) {
+    this.message = message;
+    this.status = status;
+    this.code = code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", ErrorDetails.class.getSimpleName() + "[", "]")
+        .add("message='" + message + "'")
+        .add("status='" + status + "'")
+        .add("code='" + code + "'")
+        .toString();
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionContent.java
@@ -1,0 +1,42 @@
+package ee.carlrobert.llm.client.google.completion;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@JsonInclude(Include.NON_NULL)
+public class GoogleCompletionContent {
+
+  private List<GoogleContentPart> parts;
+  private String role;
+
+  public GoogleCompletionContent() {
+  }
+
+  public GoogleCompletionContent(List<String> texts) {
+    this(null, texts);
+  }
+
+  public GoogleCompletionContent(String role, List<String> texts) {
+    this.parts = texts.stream().map(GoogleContentPart::new).collect(Collectors.toList());
+    this.role = role;
+  }
+
+  public List<GoogleContentPart> getParts() {
+    return parts;
+  }
+
+  public void setParts(
+      List<GoogleContentPart> parts) {
+    this.parts = parts;
+  }
+
+  public String getRole() {
+    return role;
+  }
+
+  public void setRole(String role) {
+    this.role = role;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionRequest.java
@@ -1,0 +1,103 @@
+package ee.carlrobert.llm.client.google.completion;
+
+import ee.carlrobert.llm.completion.CompletionRequest;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GoogleCompletionRequest implements CompletionRequest {
+
+  private final List<GoogleCompletionContent> contents;
+  private final List<SafetySetting> safetySettings;
+  private final GoogleGenerationConfig generationConfig;
+
+  public GoogleCompletionRequest(Builder builder) {
+    this.contents = builder.contents;
+    this.safetySettings = builder.safetySettings;
+    this.generationConfig = builder.generationConfig;
+  }
+
+  public List<GoogleCompletionContent> getContents() {
+    return contents;
+  }
+
+  public List<SafetySetting> getSafetySettings() {
+    return safetySettings;
+  }
+
+  public GoogleGenerationConfig getGenerationConfig() {
+    return generationConfig;
+  }
+
+  /**
+   * <a href="https://ai.google.dev/api/rest/v1/HarmCategory?authuser=1">Harm Category</a>.
+   */
+  public enum HarmCategory {
+    HARM_CATEGORY_UNSPECIFIED,
+    HARM_CATEGORY_DEROGATORY,
+    HARM_CATEGORY_TOXICITY,
+    HARM_CATEGORY_VIOLENCE,
+    HARM_CATEGORY_SEXUAL,
+    HARM_CATEGORY_MEDICAL,
+    HARM_CATEGORY_DANGEROUS,
+    HARM_CATEGORY_HARASSMENT,
+    HARM_CATEGORY_HATE_SPEECH,
+    HARM_CATEGORY_SEXUALLY_EXPLICIT,
+    HARM_CATEGORY_DANGEROUS_CONTENT;
+  }
+
+  /**
+   * <a href="https://ai.google.dev/api/rest/v1/SafetySetting?authuser=1#harmblockthreshold">Harm
+   * Block Threshold</a>.
+   */
+  public enum HarmBlockThreshold {
+    HARM_BLOCK_THRESHOLD_UNSPECIFIED,
+    BLOCK_LOW_AND_ABOVE,
+    BLOCK_MEDIUM_AND_ABOVE,
+    BLOCK_ONLY_HIGH,
+    BLOCK_NONE,
+  }
+
+  public static class SafetySetting {
+
+    private final HarmCategory category;
+    private final HarmBlockThreshold threshold;
+
+    public SafetySetting(HarmCategory category, HarmBlockThreshold threshold) {
+      this.category = category;
+      this.threshold = threshold;
+    }
+
+    public HarmCategory getCategory() {
+      return category;
+    }
+
+    public HarmBlockThreshold getThreshold() {
+      return threshold;
+    }
+  }
+
+  public static class Builder {
+
+    private List<GoogleCompletionContent> contents;
+    private List<SafetySetting> safetySettings = new ArrayList<>();
+    private GoogleGenerationConfig generationConfig = new GoogleGenerationConfig.Builder().build();
+
+    public Builder(List<GoogleCompletionContent> contents) {
+      this.contents = contents;
+    }
+
+    public Builder safetySettings(List<SafetySetting> safetySettings) {
+      this.safetySettings = safetySettings;
+      return this;
+    }
+
+    public Builder generationConfig(GoogleGenerationConfig generationConfig) {
+      this.generationConfig = generationConfig;
+      return this;
+    }
+
+    public GoogleCompletionRequest build() {
+      return new GoogleCompletionRequest(this);
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionResponse.java
@@ -1,0 +1,240 @@
+package ee.carlrobert.llm.client.google.completion;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import ee.carlrobert.llm.client.google.completion.GoogleCompletionRequest.HarmCategory;
+import java.util.List;
+
+/**
+ * <a
+ * href="https://ai.google.dev/api/rest/v1/GenerateContentResponse?authuser=1">GenerateContentResponse</a>.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleCompletionResponse {
+
+  private List<Candidate> candidates;
+  private PromptFeedback promptFeedback;
+
+  public List<Candidate> getCandidates() {
+    return candidates;
+  }
+
+  public void setCandidates(
+      List<Candidate> candidates) {
+    this.candidates = candidates;
+  }
+
+  public PromptFeedback getPromptFeedback() {
+    return promptFeedback;
+  }
+
+  public void setPromptFeedback(
+      PromptFeedback promptFeedback) {
+    this.promptFeedback = promptFeedback;
+  }
+
+  public static class CitationSource {
+
+    private int startIndex;
+    private int endIndex;
+    private String uri;
+    private String license;
+
+    public int getStartIndex() {
+      return startIndex;
+    }
+
+    public void setStartIndex(int startIndex) {
+      this.startIndex = startIndex;
+    }
+
+    public int getEndIndex() {
+      return endIndex;
+    }
+
+    public void setEndIndex(int endIndex) {
+      this.endIndex = endIndex;
+    }
+
+    public String getUri() {
+      return uri;
+    }
+
+    public void setUri(String uri) {
+      this.uri = uri;
+    }
+
+    public String getLicense() {
+      return license;
+    }
+
+    public void setLicense(String license) {
+      this.license = license;
+    }
+  }
+
+  public static class CitationMetadata {
+
+    private List<CitationSource> citationSources;
+
+    public List<CitationSource> getCitationSources() {
+      return citationSources;
+    }
+
+    public void setCitationSources(List<CitationSource> citationSources) {
+      this.citationSources = citationSources;
+    }
+  }
+
+  /**
+   * <a
+   * href="https://ai.google.dev/api/rest/v1/GenerateContentResponse?authuser=1#FinishReason">FinishReason</a>.
+   */
+  public enum FinishReason {
+    FINISH_REASON_UNSPECIFIED,
+    STOP,
+    MAX_TOKENS,
+    SAFETY,
+    RECITATION,
+    OTHER
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class Candidate {
+
+    private GoogleCompletionContent content;
+    private FinishReason finishReason;
+    private List<SafetyRating> safetyRatings;
+    private CitationMetadata citationMetaData;
+    private int tokenCount;
+    private int index;
+
+    public GoogleCompletionContent getContent() {
+      return content;
+    }
+
+    public void setContent(GoogleCompletionContent content) {
+      this.content = content;
+    }
+
+    public FinishReason getFinishReason() {
+      return finishReason;
+    }
+
+    public void setFinishReason(
+        FinishReason finishReason) {
+      this.finishReason = finishReason;
+    }
+
+    public List<SafetyRating> getSafetyRatings() {
+      return safetyRatings;
+    }
+
+    public void setSafetyRatings(
+        List<SafetyRating> safetyRatings) {
+      this.safetyRatings = safetyRatings;
+    }
+
+    public CitationMetadata getCitationMetaData() {
+      return citationMetaData;
+    }
+
+    public void setCitationMetaData(
+        CitationMetadata citationMetaData) {
+      this.citationMetaData = citationMetaData;
+    }
+
+    public int getTokenCount() {
+      return tokenCount;
+    }
+
+    public void setTokenCount(int tokenCount) {
+      this.tokenCount = tokenCount;
+    }
+
+    public int getIndex() {
+      return index;
+    }
+
+    public void setIndex(int index) {
+      this.index = index;
+    }
+  }
+
+  /**
+   * <a
+   * href="https://ai.google.dev/api/rest/v1/GenerateContentResponse?authuser=1#HarmProbability">HarmProbability</a>.
+   */
+  public enum HarmProbability {
+    HARM_PROBABILITY_UNSPECIFIED,
+    NEGLIGIBLE,
+    LOW,
+    MEDIUM,
+    HIGH
+  }
+
+  public static class SafetyRating {
+
+    private HarmCategory category;
+    private HarmProbability probability;
+    private boolean blocked;
+
+    public HarmCategory getCategory() {
+      return category;
+    }
+
+    public void setCategory(
+        HarmCategory category) {
+      this.category = category;
+    }
+
+    public HarmProbability getProbability() {
+      return probability;
+    }
+
+    public void setProbability(HarmProbability probability) {
+      this.probability = probability;
+    }
+
+    public boolean isBlocked() {
+      return blocked;
+    }
+
+    public void setBlocked(boolean blocked) {
+      this.blocked = blocked;
+    }
+  }
+
+  /**
+   * <a
+   * href="https://ai.google.dev/api/rest/v1/GenerateContentResponse?authuser=1#BlockReason">BlockReason</a>.
+   */
+  public enum BlockReason {
+    BLOCK_REASON_UNSPECIFIED,
+    SAFETY,
+    OTHER
+  }
+
+  public static class PromptFeedback {
+
+    private BlockReason blockReason;
+    private List<SafetyRating> safetyRatings;
+
+    public BlockReason getBlockReason() {
+      return blockReason;
+    }
+
+    public void setBlockReason(
+        BlockReason blockReason) {
+      this.blockReason = blockReason;
+    }
+
+    public List<SafetyRating> getSafetyRatings() {
+      return safetyRatings;
+    }
+
+    public void setSafetyRatings(
+        List<SafetyRating> safetyRatings) {
+      this.safetyRatings = safetyRatings;
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleContentPart.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleContentPart.java
@@ -1,0 +1,64 @@
+package ee.carlrobert.llm.client.google.completion;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+public class GoogleContentPart {
+
+  private String text;
+  private Blob inlineData;
+
+  public GoogleContentPart() {
+  }
+
+  public GoogleContentPart(String text) {
+    this(text, null);
+  }
+
+  public GoogleContentPart(String text, Blob inlineData) {
+    this.text = text;
+    this.inlineData = inlineData;
+  }
+
+  public String getText() {
+    return text;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+
+  public Blob getInlineData() {
+    return inlineData;
+  }
+
+  public void setInlineData(Blob inlineData) {
+    this.inlineData = inlineData;
+  }
+
+  /**
+   * <a href="https://ai.google.dev/api/rest/v1/Content?authuser=1#Blob">Blob</a>.
+   */
+  public static class Blob {
+
+    private String mimeType;
+    private String data;
+
+    public String getMimeType() {
+      return mimeType;
+    }
+
+    public void setMimeType(String mimeType) {
+      this.mimeType = mimeType;
+    }
+
+    public String getData() {
+      return data;
+    }
+
+    public void setData(String data) {
+      this.data = data;
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleGenerationConfig.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleGenerationConfig.java
@@ -1,0 +1,94 @@
+package ee.carlrobert.llm.client.google.completion;
+
+import java.util.List;
+
+/**
+ * <a href="https://ai.google.dev/api/rest/v1/GenerationConfig?authuser=1">Gemini API
+ * GenerationConfig</a>.
+ */
+public class GoogleGenerationConfig {
+
+  private final List<String> stopSequences;
+  private final int candidateCount;
+  private final double temperature;
+  private final int maxOutputTokens;
+  private final double topP;
+  private final int topK;
+
+  public GoogleGenerationConfig(Builder builder) {
+    this.stopSequences = builder.stopSequences;
+    this.candidateCount = builder.candidateCount;
+    this.temperature = builder.temperature;
+    this.maxOutputTokens = builder.maxOutputTokens;
+    this.topP = builder.topP;
+    this.topK = builder.topK;
+  }
+
+  public List<String> getStopSequences() {
+    return stopSequences;
+  }
+
+  public int getCandidateCount() {
+    return candidateCount;
+  }
+
+  public double getTemperature() {
+    return temperature;
+  }
+
+  public int getMaxOutputTokens() {
+    return maxOutputTokens;
+  }
+
+  public double getTopP() {
+    return topP;
+  }
+
+  public int getTopK() {
+    return topK;
+  }
+
+  public static class Builder {
+
+    private List<String> stopSequences;
+    private int candidateCount = 1;
+    private double temperature = 0.9;
+    private int maxOutputTokens = 256;
+    private double topP = 0.9;
+    private int topK = 40;
+
+    public Builder stopSequences(List<String> stopSequences) {
+      this.stopSequences = stopSequences;
+      return this;
+    }
+
+    public Builder candidateCount(int candidateCount) {
+      this.candidateCount = candidateCount;
+      return this;
+    }
+
+    public Builder temperature(double temperature) {
+      this.temperature = temperature;
+      return this;
+    }
+
+    public Builder maxOutputTokens(int maxOutputTokens) {
+      this.maxOutputTokens = maxOutputTokens;
+      return this;
+    }
+
+    public Builder topP(double topP) {
+      this.topP = topP;
+      return this;
+    }
+
+    public Builder topK(int topK) {
+      this.topK = topK;
+      return this;
+    }
+
+    public GoogleGenerationConfig build() {
+      return new GoogleGenerationConfig(this);
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/embedding/ContentEmbedding.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/embedding/ContentEmbedding.java
@@ -1,0 +1,14 @@
+package ee.carlrobert.llm.client.google.embedding;
+
+public class ContentEmbedding {
+
+  private double[] values;
+
+  public double[] getValues() {
+    return values;
+  }
+
+  public void setValues(double[] values) {
+    this.values = values;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/embedding/GoogleBatchEmbeddingResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/embedding/GoogleBatchEmbeddingResponse.java
@@ -1,0 +1,19 @@
+package ee.carlrobert.llm.client.google.embedding;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleBatchEmbeddingResponse {
+
+  private List<ContentEmbedding> embeddings;
+
+  public List<ContentEmbedding> getEmbeddings() {
+    return embeddings;
+  }
+
+  public void setEmbeddings(List<ContentEmbedding> embedding) {
+    this.embeddings = embedding;
+  }
+
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/embedding/GoogleEmbeddingContentRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/embedding/GoogleEmbeddingContentRequest.java
@@ -1,0 +1,33 @@
+package ee.carlrobert.llm.client.google.embedding;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import ee.carlrobert.llm.client.google.completion.GoogleCompletionContent;
+import java.util.List;
+
+@JsonInclude(Include.NON_NULL)
+public class GoogleEmbeddingContentRequest extends GoogleEmbeddingRequest {
+
+  private String model;
+
+  public GoogleEmbeddingContentRequest(String content, String model) {
+    this(new Builder(new GoogleCompletionContent(List.of(content))), model);
+  }
+
+  public GoogleEmbeddingContentRequest(List<String> contents, String model) {
+    this(new Builder(new GoogleCompletionContent(contents)), model);
+  }
+
+  public GoogleEmbeddingContentRequest(Builder builder, String model) {
+    super(builder);
+    this.model = model;
+  }
+
+  public String getModel() {
+    return model;
+  }
+
+  public void setModel(String model) {
+    this.model = model;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/embedding/GoogleEmbeddingRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/embedding/GoogleEmbeddingRequest.java
@@ -1,0 +1,84 @@
+package ee.carlrobert.llm.client.google.embedding;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import ee.carlrobert.llm.client.google.completion.GoogleCompletionContent;
+import java.util.List;
+
+@JsonInclude(Include.NON_NULL)
+public class GoogleEmbeddingRequest {
+
+  private final GoogleCompletionContent content;
+  private final TaskType taskType;
+  private final String title;
+  private final Integer outputDimensionality;
+
+  public GoogleEmbeddingRequest(Builder builder) {
+    this.content = builder.content;
+    this.taskType = builder.taskType;
+    this.title = builder.title;
+    this.outputDimensionality = builder.outputDimensionality;
+  }
+
+  public GoogleCompletionContent getContent() {
+    return content;
+  }
+
+  public TaskType getTaskType() {
+    return taskType;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public Integer getOutputDimensionality() {
+    return outputDimensionality;
+  }
+
+  /**
+   * <a href="https://ai.google.dev/api/rest/v1/TaskType?authuser=1">TaskType</a>.
+   */
+  public enum TaskType {
+    TASK_TYPE_UNSPECIFIED,
+    RETRIEVAL_QUERY,
+    RETRIEVAL_DOCUMENT,
+    SEMANTIC_SIMILARITY,
+    CLASSIFICATION,
+    CLUSTERING,
+    QUESTION_ANSWERING,
+    FACT_VERIFICATION
+  }
+
+  public static class Builder {
+
+    private GoogleCompletionContent content;
+    private TaskType taskType = TaskType.RETRIEVAL_DOCUMENT; // Set default value
+    private String title;
+    private Integer outputDimensionality;
+
+    public Builder(GoogleCompletionContent content) {
+      this.content = content;
+    }
+
+    public Builder taskType(TaskType taskType) {
+      this.taskType = taskType;
+      return this;
+    }
+
+    public Builder title(String title) {
+      this.title = title;
+      return this;
+    }
+
+    public Builder outputDimensionality(int outputDimensionality) {
+      this.outputDimensionality = outputDimensionality;
+      return this;
+    }
+
+    public GoogleEmbeddingRequest build() {
+      return new GoogleEmbeddingRequest(this);
+    }
+  }
+
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/embedding/GoogleEmbeddingResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/embedding/GoogleEmbeddingResponse.java
@@ -1,0 +1,18 @@
+package ee.carlrobert.llm.client.google.embedding;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleEmbeddingResponse {
+
+  private ContentEmbedding embedding;
+
+  public ContentEmbedding getEmbedding() {
+    return embedding;
+  }
+
+  public void setEmbedding(ContentEmbedding embedding) {
+    this.embedding = embedding;
+  }
+
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/models/GoogleModel.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/models/GoogleModel.java
@@ -1,0 +1,35 @@
+package ee.carlrobert.llm.client.google.models;
+
+public enum GoogleModel {
+  GEMINI_1_0_PRO("gemini-1.0-pro", "Gemini 1.0 Pro (32k)", 30720 + 2048),
+  GEMINI_1_0_PRO_001("gemini-1.0-pro-001", "Gemini 1.0 Pro 001 (32k)", 30720 + 2048),
+  GEMINI_1_0_PRO_LATEST("gemini-1.0-pro-latest", "Gemini 1.0 Pro Latest (32k)", 30720 + 2048),
+  GEMINI_1_0_PRO_VISION_LATEST("gemini-1.0-pro-vision-latest", "Gemini 1.0 Pro Vision Latest (16k)",
+      12288 + 4096),
+  GEMINI_PRO("gemini-pro", "Gemini Pro (32k)", 30720 + 2048),
+  GEMINI_PRO_VISION("gemini-pro-vision", "Gemini Pro Vision (16k)", 12288 + 4096),
+  EMBEDDING_001("embedding-001", "Embedding 001 (2k)", 2048 + 1),
+  TEXT_EMBEDDING_004("text-embedding-004", "Text Embedding (2k)", 2048 + 1);
+
+  private final String code;
+  private final String description;
+  private final int maxTokens;
+
+  GoogleModel(String code, String description, int maxTokens) {
+    this.code = code;
+    this.description = description;
+    this.maxTokens = maxTokens;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public int getMaxTokens() {
+    return maxTokens;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/models/GoogleModelsResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/models/GoogleModelsResponse.java
@@ -1,0 +1,130 @@
+package ee.carlrobert.llm.client.google.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleModelsResponse {
+
+  private List<GeminiModelDetails> models;
+  private String nextPageToken;
+
+  public List<GeminiModelDetails> getModels() {
+    return models;
+  }
+
+  public void setModels(List<GeminiModelDetails> models) {
+    this.models = models;
+  }
+
+  public String getNextPageToken() {
+    return nextPageToken;
+  }
+
+  public void setNextPageToken(String nextPageToken) {
+    this.nextPageToken = nextPageToken;
+  }
+
+  public static class GeminiModelDetails {
+
+    private String name;
+    private String baseModelId;
+    private String version;
+    private String displayName;
+    private String description;
+    private int inputTokenLimit;
+    private int outputTokenLimit;
+    private List<String> supportedGenerationMethods;
+    private double temperature;
+    private double topP;
+    private int topK;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getBaseModelId() {
+      return baseModelId;
+    }
+
+    public void setBaseModelId(String baseModelId) {
+      this.baseModelId = baseModelId;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public void setVersion(String version) {
+      this.version = version;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public void setDescription(String description) {
+      this.description = description;
+    }
+
+    public int getInputTokenLimit() {
+      return inputTokenLimit;
+    }
+
+    public void setInputTokenLimit(int inputTokenLimit) {
+      this.inputTokenLimit = inputTokenLimit;
+    }
+
+    public int getOutputTokenLimit() {
+      return outputTokenLimit;
+    }
+
+    public void setOutputTokenLimit(int outputTokenLimit) {
+      this.outputTokenLimit = outputTokenLimit;
+    }
+
+    public List<String> getSupportedGenerationMethods() {
+      return supportedGenerationMethods;
+    }
+
+    public void setSupportedGenerationMethods(List<String> supportedGenerationMethods) {
+      this.supportedGenerationMethods = supportedGenerationMethods;
+    }
+
+    public double getTemperature() {
+      return temperature;
+    }
+
+    public void setTemperature(double temperature) {
+      this.temperature = temperature;
+    }
+
+    public double getTopP() {
+      return topP;
+    }
+
+    public void setTopP(double topP) {
+      this.topP = topP;
+    }
+
+    public int getTopK() {
+      return topK;
+    }
+
+    public void setTopK(int topK) {
+      this.topK = topK;
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/google/models/GoogleTokensResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/models/GoogleTokensResponse.java
@@ -1,0 +1,17 @@
+package ee.carlrobert.llm.client.google.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleTokensResponse {
+
+  private int totalTokens;
+
+  public int getTotalTokens() {
+    return totalTokens;
+  }
+
+  public void setTotalTokens(int totalTokens) {
+    this.totalTokens = totalTokens;
+  }
+}

--- a/src/test/java/ee/carlrobert/llm/client/GoogleClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/GoogleClientTest.java
@@ -1,0 +1,341 @@
+package ee.carlrobert.llm.client;
+
+import static ee.carlrobert.llm.client.util.JSONUtil.e;
+import static ee.carlrobert.llm.client.util.JSONUtil.jsonArray;
+import static ee.carlrobert.llm.client.util.JSONUtil.jsonMap;
+import static ee.carlrobert.llm.client.util.JSONUtil.jsonMapResponse;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ee.carlrobert.llm.client.google.GoogleClient;
+import ee.carlrobert.llm.client.google.completion.GoogleCompletionContent;
+import ee.carlrobert.llm.client.google.completion.GoogleCompletionRequest;
+import ee.carlrobert.llm.client.google.completion.GoogleGenerationConfig;
+import ee.carlrobert.llm.client.google.embedding.GoogleEmbeddingContentRequest;
+import ee.carlrobert.llm.client.google.models.GoogleModel;
+import ee.carlrobert.llm.client.http.ResponseEntity;
+import ee.carlrobert.llm.client.http.exchange.BasicHttpExchange;
+import ee.carlrobert.llm.client.http.exchange.StreamHttpExchange;
+import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
+import ee.carlrobert.llm.completion.CompletionEventListener;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import okhttp3.sse.EventSource;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class GoogleClientTest extends BaseTest {
+
+  @Test
+  void shouldStreamChatCompletion() {
+    var prompt = "TEST_PROMPT";
+    var resultMessageBuilder = new StringBuilder();
+    expectGoogle((StreamHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo(
+          "/v1/models/gemini-1.0-pro:streamGenerateContent");
+      assertThat(request.getUri().getQuery()).isEqualTo("key=TEST_API_KEY&alt=sse");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getBody())
+          .extracting(
+              "generationConfig.temperature",
+              "generationConfig.maxOutputTokens",
+              "contents"
+          )
+          .containsExactly(
+              0.5,
+              500,
+              List.of(Map.of("parts", List.of(Map.of("text", prompt)), "role", "user"))
+          );
+      return List.of(
+          jsonMapResponse("candidates",
+              jsonArray(jsonMap("content", jsonMap("parts", jsonArray(jsonMap("text", "Hello")))))),
+          jsonMapResponse("candidates",
+              jsonArray(jsonMap("content", jsonMap("parts", jsonArray(jsonMap("text", "!")))))));
+    });
+
+    new GoogleClient.Builder("TEST_API_KEY")
+        .build()
+        .getChatCompletionAsync(
+            new GoogleCompletionRequest.Builder(
+                List.of(new GoogleCompletionContent("user", List.of(prompt))))
+                .generationConfig(new GoogleGenerationConfig.Builder()
+                    .temperature(0.5)
+                    .maxOutputTokens(500)
+                    .build())
+                .build(),
+            GoogleModel.GEMINI_1_0_PRO,
+            new CompletionEventListener<String>() {
+              @Override
+              public void onMessage(String message, EventSource eventSource) {
+                resultMessageBuilder.append(message);
+              }
+            });
+
+    await().atMost(5, SECONDS).until(() -> "Hello!".contentEquals(resultMessageBuilder));
+  }
+
+
+  @Test
+  void shouldGetChatCompletion() {
+    var prompt = "TEST_PROMPT";
+    expectGoogle((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo(
+          "/v1/models/gemini-1.0-pro:generateContent");
+      assertThat(request.getUri().getQuery()).isEqualTo("key=TEST_API_KEY");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getBody())
+          .extracting(
+              "generationConfig.temperature",
+              "generationConfig.maxOutputTokens",
+              "contents"
+          )
+          .containsExactly(
+              0.5,
+              500,
+              List.of(Map.of("parts", List.of(Map.of("text", prompt)), "role", "user"))
+          );
+      return new ResponseEntity(new ObjectMapper().writeValueAsString(Map.of("candidates", List.of(
+          Map.of("content", Map.of(
+              "role", "assistant",
+              "parts", List.of(Map.of("text", "This is a test"))))))));
+    });
+
+    var response = new GoogleClient.Builder("TEST_API_KEY")
+        .build()
+        .getChatCompletion(new GoogleCompletionRequest.Builder(
+                List.of(new GoogleCompletionContent("user", List.of(prompt))))
+                .generationConfig(new GoogleGenerationConfig.Builder()
+                    .maxOutputTokens(500)
+                    .temperature(0.5)
+                    .build())
+                .build(),
+            GoogleModel.GEMINI_1_0_PRO);
+
+    assertThat(response.getCandidates())
+        .extracting("content.role")
+        .containsExactly("assistant");
+
+    assertThat(response.getCandidates())
+        .first()
+        .extracting("content.parts")
+        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .first()
+        .extracting("text")
+        .isEqualTo("This is a test");
+  }
+
+
+  @Test
+  void shouldHandleInvalidApiKeyError() {
+    var errorMessageBuilder = new StringBuilder();
+    var errorResponse = jsonMapResponse("error", jsonMap(
+        e("message", "API key not valid. Please pass a valid API key."),
+        e("status", "INVALID_ARGUMENT"),
+        e("code", "400")));
+    expectGoogle((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo(
+          "/v1/models/gemini-1.0-pro:streamGenerateContent");
+      return new ResponseEntity(400, errorResponse);
+    });
+
+    new GoogleClient.Builder("TEST_API_KEY")
+        .build()
+        .getChatCompletionAsync(
+            new GoogleCompletionRequest.Builder(
+                List.of(new GoogleCompletionContent("user", List.of("TEST_USER_PROMPT"))))
+                .build(),
+            GoogleModel.GEMINI_1_0_PRO,
+            new CompletionEventListener<>() {
+              @Override
+              public void onError(ErrorDetails error, Throwable t) {
+                assertThat(error.getCode()).isEqualTo("400");
+                assertThat(error.getMessage()).isEqualTo(
+                    "API key not valid. Please pass a valid API key.");
+                assertThat(error.getType()).isEqualTo("INVALID_ARGUMENT");
+                errorMessageBuilder.append(error.getMessage());
+              }
+            });
+
+    await().atMost(5, SECONDS)
+        .until(() -> "API key not valid. Please pass a valid API key.".contentEquals(
+            errorMessageBuilder));
+  }
+
+  @Test
+  void shouldHandleUnknownApiError() {
+    var errorMessageBuilder = new StringBuilder();
+    var errorResponse = jsonMapResponse("error_details", "Server error");
+    expectGoogle((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo(
+          "/v1/models/gemini-1.0-pro:streamGenerateContent");
+      return new ResponseEntity(500, errorResponse);
+    });
+
+    new GoogleClient.Builder("TEST_API_KEY")
+        .build()
+        .getChatCompletionAsync(
+            new GoogleCompletionRequest.Builder(
+                List.of(new GoogleCompletionContent("user", List.of("TEST_PROMPT"))))
+                .build(),
+            GoogleModel.GEMINI_1_0_PRO,
+            new CompletionEventListener<>() {
+              @Override
+              public void onError(ErrorDetails error, Throwable t) {
+                errorMessageBuilder.append(error.getMessage());
+              }
+            });
+
+    await().atMost(5, SECONDS)
+        .until(() -> ("Unknown API response. "
+            + "Code: 500, "
+            + "Body: {\"error_details\":\"Server error\"}").contentEquals(errorMessageBuilder));
+  }
+
+  static Stream<Arguments> testEmbeddings() {
+    double[] one = {1};
+    var embeddingOne = jsonMapResponse("embedding", jsonMap("values", one));
+    var embeddingNull = jsonMapResponse("embedding", jsonMap("values", null));
+    return Stream.of(
+        Arguments.of("{}", null),
+        Arguments.of(jsonMapResponse("embedding", null), null),
+        Arguments.of(embeddingOne, one),
+        Arguments.of(embeddingNull, null)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testEmbeddings")
+  void shouldGetEmbeddings(String json, double[] expected) {
+    expectGoogle((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo(
+          "/v1/models/text-embedding-004:embedContent");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getUri().getQuery()).isEqualTo("key=TEST_API_KEY");
+      return new ResponseEntity(200, json);
+    });
+
+    var result = new GoogleClient.Builder("TEST_API_KEY")
+        .build()
+        .getEmbedding(List.of("TEST_PROMPT"), GoogleModel.TEXT_EMBEDDING_004);
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> testBatchEmbeddings() {
+    double[] one = {1};
+    var embeddingsOne = jsonMapResponse("embeddings",
+        jsonArray(jsonMap("values", one)));
+    var embeddingsNull = jsonMapResponse("embeddings", null);
+    double[] two = {2};
+    var embeddingsTwo = jsonMapResponse("embeddings",
+        jsonArray(
+            jsonMap("values", one),
+            jsonMap("values", two)
+        ));
+    return Stream.of(
+        Arguments.of("{}", null),
+        Arguments.of(jsonMapResponse("embeddings", null), null),
+        Arguments.of(embeddingsOne, List.of(one)),
+        Arguments.of(embeddingsNull, null),
+        Arguments.of(embeddingsTwo, List.of(one, two))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testBatchEmbeddings")
+  void shouldGetBatchEmbeddings(String json, List<double[]> expected) {
+    expectGoogle((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo(
+          "/v1/models/text-embedding-004:batchEmbedContents");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getUri().getQuery()).isEqualTo("key=TEST_API_KEY");
+      return new ResponseEntity(200, json);
+    });
+
+    var result = new GoogleClient.Builder("TEST_API_KEY")
+        .build()
+        .getBatchEmbeddings(List.of(new GoogleEmbeddingContentRequest("TEST_PROMPT",
+            GoogleModel.TEXT_EMBEDDING_004.getCode())), GoogleModel.TEXT_EMBEDDING_004);
+    if (expected == null) {
+      assertThat(result).isNull();
+    } else {
+      assertThat(result).containsExactlyElementsOf(expected);
+    }
+  }
+
+
+  @Test
+  void shouldGetModels() {
+    expectGoogle((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo(
+          "/v1/models");
+      assertThat(request.getUri().getQuery()).isEqualTo("pageSize=1&key=TEST_API_KEY");
+      assertThat(request.getMethod()).isEqualTo("GET");
+      return new ResponseEntity(new ObjectMapper().writeValueAsString(
+          Map.of("models", List.of(Map.of("name", "gemini-1.5-pro",
+              "displayName", "Gemini Pro 1.5",
+              "supportedGenerationMethods", List.of("generateContent", "embedContent"))))));
+    });
+
+    var response = new GoogleClient.Builder("TEST_API_KEY")
+        .build()
+        .getModels(1, null);
+
+    assertThat(response.getModels())
+        .hasSize(1)
+        .first()
+        .extracting("name", "displayName", "supportedGenerationMethods")
+        .containsExactly("gemini-1.5-pro", "Gemini Pro 1.5",
+            List.of("generateContent", "embedContent"));
+  }
+
+  @Test
+  void shouldGetModel() {
+    expectGoogle((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo(
+          "/v1/models/gemini-1.5-pro");
+      assertThat(request.getUri().getQuery()).isEqualTo("key=TEST_API_KEY");
+      assertThat(request.getMethod()).isEqualTo("GET");
+      return new ResponseEntity(new ObjectMapper().writeValueAsString(
+          Map.of("name", "gemini-1.5-pro",
+              "displayName", "Gemini Pro 1.5",
+              "supportedGenerationMethods", List.of("generateContent", "embedContent"))));
+    });
+
+    var response = new GoogleClient.Builder("TEST_API_KEY")
+        .build()
+        .getModel("gemini-1.5-pro");
+
+    assertThat(response)
+        .extracting("name", "displayName", "supportedGenerationMethods")
+        .containsExactly("gemini-1.5-pro", "Gemini Pro 1.5",
+            List.of("generateContent", "embedContent"));
+  }
+
+  @Test
+  void shouldGetCountTokens() {
+    expectGoogle((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo(
+          "/v1/models/gemini-1.0-pro:countTokens");
+      assertThat(request.getUri().getQuery()).isEqualTo("key=TEST_API_KEY");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getBody())
+          .extracting("contents")
+          .isEqualTo( List.of(Map.of("parts", List.of(Map.of("text", "test")))));
+      return new ResponseEntity(new ObjectMapper().writeValueAsString(
+          Map.of("totalTokens", 1)));
+    });
+
+    var response = new GoogleClient.Builder("TEST_API_KEY")
+        .build()
+        .getCountTokens(List.of(new GoogleCompletionContent(List.of("test"))), GoogleModel.GEMINI_1_0_PRO);
+
+    assertThat(response.getTotalTokens()).isEqualTo(1);
+  }
+}

--- a/src/test/java/ee/carlrobert/llm/client/GoogleClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/GoogleClientTest.java
@@ -327,14 +327,15 @@ class GoogleClientTest extends BaseTest {
       assertThat(request.getMethod()).isEqualTo("POST");
       assertThat(request.getBody())
           .extracting("contents")
-          .isEqualTo( List.of(Map.of("parts", List.of(Map.of("text", "test")))));
+          .isEqualTo(List.of(Map.of("parts", List.of(Map.of("text", "test")))));
       return new ResponseEntity(new ObjectMapper().writeValueAsString(
           Map.of("totalTokens", 1)));
     });
 
     var response = new GoogleClient.Builder("TEST_API_KEY")
         .build()
-        .getCountTokens(List.of(new GoogleCompletionContent(List.of("test"))), GoogleModel.GEMINI_1_0_PRO);
+        .getCountTokens(List.of(
+            new GoogleCompletionContent(List.of("test"))), GoogleModel.GEMINI_1_0_PRO);
 
     assertThat(response.getTotalTokens()).isEqualTo(1);
   }

--- a/src/test/java/ee/carlrobert/llm/client/mixin/ExternalService.java
+++ b/src/test/java/ee/carlrobert/llm/client/mixin/ExternalService.java
@@ -9,7 +9,8 @@ public enum ExternalService implements Service {
   AZURE("azure.openai.baseUrl"),
   YOU("you.baseUrl"),
   LLAMA("llama.baseUrl"),
-  OLLAMA("ollama.baseUrl");
+  OLLAMA("ollama.baseUrl"),
+  GOOGLE("google.baseUrl");
 
   private final String urlProperty;
 

--- a/src/test/java/ee/carlrobert/llm/client/mixin/ExternalServiceTestMixin.java
+++ b/src/test/java/ee/carlrobert/llm/client/mixin/ExternalServiceTestMixin.java
@@ -3,6 +3,7 @@ package ee.carlrobert.llm.client.mixin;
 
 import static ee.carlrobert.llm.client.mixin.ExternalService.ANTHROPIC;
 import static ee.carlrobert.llm.client.mixin.ExternalService.AZURE;
+import static ee.carlrobert.llm.client.mixin.ExternalService.GOOGLE;
 import static ee.carlrobert.llm.client.mixin.ExternalService.LLAMA;
 import static ee.carlrobert.llm.client.mixin.ExternalService.OLLAMA;
 import static ee.carlrobert.llm.client.mixin.ExternalService.OPENAI;
@@ -68,6 +69,10 @@ public interface ExternalServiceTestMixin {
 
   default void expectOllama(Exchange exchange) {
     addExpectation(OLLAMA, exchange);
+  }
+
+  default void expectGoogle(Exchange exchange) {
+    addExpectation(GOOGLE, exchange);
   }
 
   private void addExpectation(ExternalService externalService, Exchange exchange) {


### PR DESCRIPTION
Adds `GoogleClient` to use Gemini Models with Google's API
This includes all [/v1/models Endpoints](https://ai.google.dev/api/rest/v1/models?authuser=1) 

Note: Be aware of that the API is not yet available everywhere, e.g. many countries in Europe are not yet supported (see https://ai.google.dev/gemini-api/docs/available-regions)