### PR TITLE
Google API Fixes

### DIFF
--- a/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionContent.java
@@ -23,6 +23,11 @@ public class GoogleCompletionContent {
     this.role = role;
   }
 
+  public GoogleCompletionContent(List<GoogleContentPart> parts, String role) {
+    this.parts = parts;
+    this.role = role;
+  }
+
   public List<GoogleContentPart> getParts() {
     return parts;
   }

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleContentPart.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleContentPart.java
@@ -2,6 +2,8 @@ package ee.carlrobert.llm.client.google.completion;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.Base64;
+import java.util.Base64.Encoder;
 
 @JsonInclude(Include.NON_NULL)
 public class GoogleContentPart {
@@ -42,8 +44,27 @@ public class GoogleContentPart {
    */
   public static class Blob {
 
+    public static final Encoder ENCODER = Base64.getEncoder();
+
     private String mimeType;
+
+    /**
+     * base64 encoded.
+     */
     private String data;
+
+    public Blob() {
+    }
+
+    public Blob(String mimeType, byte[] data) {
+      this.mimeType = mimeType;
+      this.data = ENCODER.encodeToString(data);
+    }
+
+    public Blob(String mimeType, String base64EncodedData) {
+      this.mimeType = mimeType;
+      this.data = base64EncodedData;
+    }
 
     public String getMimeType() {
       return mimeType;

--- a/src/main/java/ee/carlrobert/llm/client/google/models/GoogleModel.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/models/GoogleModel.java
@@ -1,5 +1,7 @@
 package ee.carlrobert.llm.client.google.models;
 
+import java.util.Arrays;
+
 public enum GoogleModel {
   GEMINI_1_0_PRO("gemini-1.0-pro", "Gemini 1.0 Pro (32k)", 30720 + 2048),
   GEMINI_1_0_PRO_001("gemini-1.0-pro-001", "Gemini 1.0 Pro 001 (32k)", 30720 + 2048),
@@ -31,5 +33,16 @@ public enum GoogleModel {
 
   public int getMaxTokens() {
     return maxTokens;
+  }
+
+  @Override
+  public String toString() {
+    return description;
+  }
+
+  public static GoogleModel findByCode(String code) {
+    return Arrays.stream(GoogleModel.values())
+        .filter(item -> item.getCode().equals(code))
+        .findFirst().orElseThrow();
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,4 @@ anthropic.baseUrl=https://api.anthropic.com
 you.baseUrl=https://you.com
 llama.baseUrl=http://localhost:8080
 ollama.baseUrl=http://localhost:11434
+google.baseUrl=https://generativelanguage.googleapis.com


### PR DESCRIPTION
Minor fixes for the Google Gemini API:

- set default `google.baseUrl` 
- add `toString()` to `GoogleModel`
- base64 encode `Blob.data`