### PR TITLE
Image generation support

### DIFF
--- a/src/main/java/ee/carlrobert/llm/client/azure/AzureClient.java
+++ b/src/main/java/ee/carlrobert/llm/client/azure/AzureClient.java
@@ -134,7 +134,7 @@ public class AzureClient {
         request.getOverriddenPath() == null
             ? "/openai/deployments/%s/images/generations?api-version=%s"
             : request.getOverriddenPath(),
-        requestParams.getDeploymentId(),
+        request.getModel(),
         requestParams.getApiVersion());
   }
 

--- a/src/main/java/ee/carlrobert/llm/client/azure/AzureClient.java
+++ b/src/main/java/ee/carlrobert/llm/client/azure/AzureClient.java
@@ -17,13 +17,11 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import okhttp3.Headers;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.sse.EventSource;
 import okhttp3.sse.EventSources;
 
@@ -63,9 +61,9 @@ public class AzureClient {
 
   public OpenAiImageGenerationResponse getImageGeneration(OpenAIImageGenerationRequest request) {
     try (var response = httpClient.newBuilder()
-            .readTimeout(60, TimeUnit.SECONDS)
-            .callTimeout(60, TimeUnit.SECONDS).build()
-            .newCall(buildHttpRequest(request)).execute()) {
+        .readTimeout(60, TimeUnit.SECONDS)
+        .callTimeout(60, TimeUnit.SECONDS).build()
+        .newCall(buildHttpRequest(request)).execute()) {
       return DeserializationUtil.mapResponse(response, OpenAiImageGenerationResponse.class);
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -98,14 +96,14 @@ public class AzureClient {
     headers.put("Content-Type", "application/json");
     try {
       return new Request.Builder()
-              .url(url + getImageGenerationPath(imageRequest))
-              .headers(Headers.of(headers))
-              .post(RequestBody.create(
-                      OBJECT_MAPPER
-                              .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                              .writeValueAsString(imageRequest),
-                      APPLICATION_JSON))
-              .build();
+          .url(url + getImageGenerationPath(imageRequest))
+          .headers(Headers.of(headers))
+          .post(RequestBody.create(
+              OBJECT_MAPPER
+                  .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                  .writeValueAsString(imageRequest),
+              APPLICATION_JSON))
+          .build();
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Unable to process request", e);
     }
@@ -133,11 +131,11 @@ public class AzureClient {
 
   private String getImageGenerationPath(OpenAIImageGenerationRequest request) {
     return String.format(
-            request.getOverriddenPath() == null
-                    ? "/openai/deployments/%s/images/generations?api-version=%s"
-                    : request.getOverriddenPath(),
-            requestParams.getDeploymentId(),
-            requestParams.getApiVersion());
+        request.getOverriddenPath() == null
+            ? "/openai/deployments/%s/images/generations?api-version=%s"
+            : request.getOverriddenPath(),
+        requestParams.getDeploymentId(),
+        requestParams.getApiVersion());
   }
 
   private OpenAIChatCompletionEventSourceListener getEventSourceListener(

--- a/src/main/java/ee/carlrobert/llm/client/azure/AzureClient.java
+++ b/src/main/java/ee/carlrobert/llm/client/azure/AzureClient.java
@@ -48,29 +48,30 @@ public class AzureClient {
       OpenAIChatCompletionRequest request,
       CompletionEventListener<String> completionEventListener) {
     return EventSources.createFactory(httpClient)
-        .newEventSource(buildHttpRequest(request), getEventSourceListener(completionEventListener));
+        .newEventSource(buildChatRequest(request), getEventSourceListener(completionEventListener));
   }
 
   public OpenAIChatCompletionResponse getChatCompletion(OpenAIChatCompletionRequest request) {
-    try (var response = httpClient.newCall(buildHttpRequest(request)).execute()) {
+    try (var response = httpClient.newCall(buildChatRequest(request)).execute()) {
       return DeserializationUtil.mapResponse(response, OpenAIChatCompletionResponse.class);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public OpenAiImageGenerationResponse getImageGeneration(OpenAIImageGenerationRequest request) {
+  public OpenAiImageGenerationResponse getImage(OpenAIImageGenerationRequest request) {
     try (var response = httpClient.newBuilder()
         .readTimeout(60, TimeUnit.SECONDS)
-        .callTimeout(60, TimeUnit.SECONDS).build()
-        .newCall(buildHttpRequest(request)).execute()) {
+        .callTimeout(60, TimeUnit.SECONDS)
+        .build()
+        .newCall(buildImageRequest(request)).execute()) {
       return DeserializationUtil.mapResponse(response, OpenAiImageGenerationResponse.class);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public Request buildHttpRequest(OpenAIChatCompletionRequest completionRequest) {
+  private Request buildChatRequest(OpenAIChatCompletionRequest completionRequest) {
     var headers = new HashMap<>(getRequiredHeaders());
     if (completionRequest.isStream()) {
       headers.put("Accept", "text/event-stream");
@@ -90,8 +91,7 @@ public class AzureClient {
     }
   }
 
-
-  public Request buildHttpRequest(OpenAIImageGenerationRequest imageRequest) {
+  private Request buildImageRequest(OpenAIImageGenerationRequest imageRequest) {
     var headers = new HashMap<>(getRequiredHeaders());
     headers.put("Content-Type", "application/json");
     try {

--- a/src/main/java/ee/carlrobert/llm/client/azure/AzureCompletionRequestParams.java
+++ b/src/main/java/ee/carlrobert/llm/client/azure/AzureCompletionRequestParams.java
@@ -6,9 +6,12 @@ public class AzureCompletionRequestParams {
   private final String deploymentId;
   private final String apiVersion;
 
-  public AzureCompletionRequestParams(String resourceName, String deploymentId, String apiVersion) {
+
+  public AzureCompletionRequestParams(String resourceName,
+                                      String completionDeploymentId,
+                                      String apiVersion) {
     this.resourceName = resourceName;
-    this.deploymentId = deploymentId;
+    this.deploymentId = completionDeploymentId;
     this.apiVersion = apiVersion;
   }
 

--- a/src/main/java/ee/carlrobert/llm/client/azure/AzureCompletionRequestParams.java
+++ b/src/main/java/ee/carlrobert/llm/client/azure/AzureCompletionRequestParams.java
@@ -7,9 +7,10 @@ public class AzureCompletionRequestParams {
   private final String apiVersion;
 
 
-  public AzureCompletionRequestParams(String resourceName,
-                                      String completionDeploymentId,
-                                      String apiVersion) {
+  public AzureCompletionRequestParams(
+      String resourceName,
+      String completionDeploymentId,
+      String apiVersion) {
     this.resourceName = resourceName;
     this.deploymentId = completionDeploymentId;
     this.apiVersion = apiVersion;

--- a/src/main/java/ee/carlrobert/llm/client/openai/OpenAIClient.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/OpenAIClient.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Headers;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -84,7 +85,10 @@ public class OpenAIClient {
   }
 
   public OpenAiImageGenerationResponse getImageGeneration(OpenAIImageGenerationRequest request) {
-    try (var response = httpClient.newCall(buildImageGenerationRequest(request)).execute()) {
+    try (var response = httpClient.newBuilder()
+        .readTimeout(60, TimeUnit.SECONDS)
+        .callTimeout(60, TimeUnit.SECONDS).build().newCall(buildImageGenerationRequest(request))
+        .execute()) {
       return DeserializationUtil.mapResponse(response, OpenAiImageGenerationResponse.class);
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/src/main/java/ee/carlrobert/llm/client/openai/OpenAIClient.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/OpenAIClient.java
@@ -84,10 +84,10 @@ public class OpenAIClient {
     }
   }
 
-  public OpenAiImageGenerationResponse getImageGeneration(OpenAIImageGenerationRequest request) {
+  public OpenAiImageGenerationResponse getImage(OpenAIImageGenerationRequest request) {
     try (var response = httpClient.newBuilder()
         .readTimeout(60, TimeUnit.SECONDS)
-        .callTimeout(60, TimeUnit.SECONDS).build().newCall(buildImageGenerationRequest(request))
+        .callTimeout(60, TimeUnit.SECONDS).build().newCall(buildImageRequest(request))
         .execute()) {
       return DeserializationUtil.mapResponse(response, OpenAiImageGenerationResponse.class);
     } catch (IOException e) {
@@ -143,7 +143,7 @@ public class OpenAIClient {
         .build();
   }
 
-  public Request buildImageGenerationRequest(OpenAIImageGenerationRequest imageRequest) {
+  public Request buildImageRequest(OpenAIImageGenerationRequest imageRequest) {
     var headers = new HashMap<>(getRequiredHeaders());
     headers.put("Content-Type", "application/json");
     try {

--- a/src/main/java/ee/carlrobert/llm/client/openai/OpenAIClient.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/OpenAIClient.java
@@ -145,14 +145,14 @@ public class OpenAIClient {
     try {
       var overriddenPath = imageRequest.getOverriddenPath();
       return new Request.Builder()
-              .url(host + (overriddenPath == null ? "/v1/images/generations" : overriddenPath))
-              .headers(Headers.of(headers))
-              .post(RequestBody.create(
-                      OBJECT_MAPPER
-                              .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                              .writeValueAsString(imageRequest),
-                      APPLICATION_JSON))
-              .build();
+          .url(host + (overriddenPath == null ? "/v1/images/generations" : overriddenPath))
+          .headers(Headers.of(headers))
+          .post(RequestBody.create(
+              OBJECT_MAPPER
+                  .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                  .writeValueAsString(imageRequest),
+              APPLICATION_JSON))
+          .build();
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Unable to process request", e);
     }

--- a/src/main/java/ee/carlrobert/llm/client/openai/imagegen/OpenAIImageGenerationModel.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/imagegen/OpenAIImageGenerationModel.java
@@ -1,0 +1,37 @@
+package ee.carlrobert.llm.client.openai.imagegen;
+
+import ee.carlrobert.llm.imagegen.ImageGenerationModel;
+import java.util.Arrays;
+
+public enum OpenAIImageGenerationModel implements ImageGenerationModel {
+  DALL_E_2("dall-e-2", "DALL·E 2"),
+  DALL_E_3("dall-e-3", "DALL·E 3");
+  private final String code;
+  private final String description;
+
+  OpenAIImageGenerationModel(String code, String description) {
+    this.code = code;
+    this.description = description;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+
+  @Override
+  public String toString() {
+    return description;
+  }
+
+  public static OpenAIImageGenerationModel findByCode(String code) {
+    return Arrays.stream(OpenAIImageGenerationModel.values())
+        .filter(item -> item.getCode().equals(code))
+        .findFirst().orElseThrow();
+  }
+}
+

--- a/src/main/java/ee/carlrobert/llm/client/openai/imagegen/request/OpenAIImageGenerationRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/imagegen/request/OpenAIImageGenerationRequest.java
@@ -16,6 +16,13 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
   @JsonProperty("prompt")
   private final String prompt;
 
+  /**
+   * Model that should be used for image generation.
+   * Needs to be the deployment-id of the image generation model for Azure.
+   * For OpenAI this can be left empty in order to use the default.
+   */
+  @JsonProperty("model")
+  private final String model;
 
   /**
    * A text description of the desired image(s). The maximum length is 4000 characters.
@@ -68,6 +75,7 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
     this.quality = builder.quality;
     this.numberOfImages = builder.numberOfImages;
     this.overriddenPath = builder.overriddenPath;
+    this.model = builder.model;
   }
 
   public String getPrompt() {
@@ -94,6 +102,10 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
     return style;
   }
 
+  public String getModel() {
+    return model;
+  }
+
   @JsonIgnore
   public String getOverriddenPath() {
     return this.overriddenPath;
@@ -109,6 +121,7 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
     private ImageQuality quality;
     private ImageStyle style;
     private String overriddenPath;
+    private String model;
 
     public Builder(String prompt) {
       this.prompt = prompt;
@@ -127,6 +140,11 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
 
     public Builder setSize(ImageSize size) {
       this.size = size;
+      return this;
+    }
+
+    public Builder setModel(String model) {
+      this.model = model;
       return this;
     }
 

--- a/src/main/java/ee/carlrobert/llm/client/openai/imagegen/request/OpenAIImageGenerationRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/imagegen/request/OpenAIImageGenerationRequest.java
@@ -19,7 +19,6 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
 
   /**
    * A text description of the desired image(s). The maximum length is 4000 characters.
-   * </br>
    * Optional, default values will apply if no value is provided.
    */
   @JsonProperty("size")
@@ -28,7 +27,6 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
 
   /**
    * The number of images to generate.
-   * </br>
    * Optional, default values will apply if no value is provided.
    */
   @JsonProperty("n")
@@ -36,7 +34,6 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
 
   /**
    * The format in which the generated images are returned.
-   * </br>
    * Optional, default values will apply if no value is provided.
    */
   @JsonProperty("response_format")
@@ -44,7 +41,6 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
 
   /**
    * The quality of the image that will be generated.
-   * </br>
    * Optional, default values will apply if no value is provided.
    */
   @JsonProperty("quality")
@@ -52,7 +48,6 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
 
   /**
    * The style of the generated images.
-   * </br>
    * Optional, default values will apply if no value is provided.
    */
   @JsonProperty("style")
@@ -63,8 +58,6 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
    */
   @JsonIgnore
   private final String overriddenPath;
-
-
 
 
   private OpenAIImageGenerationRequest(Builder builder) {
@@ -108,6 +101,7 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
 
 
   public static class Builder {
+
     private String prompt;
     private ImageSize size;
     private int numberOfImages;
@@ -156,7 +150,7 @@ public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
     }
 
     public void setOverriddenPath(String overriddenPath) {
-        this.overriddenPath = overriddenPath;
+      this.overriddenPath = overriddenPath;
     }
   }
 

--- a/src/main/java/ee/carlrobert/llm/client/openai/imagegen/request/OpenAIImageGenerationRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/imagegen/request/OpenAIImageGenerationRequest.java
@@ -1,0 +1,232 @@
+package ee.carlrobert.llm.client.openai.imagegen.request;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import ee.carlrobert.llm.imagegen.ImageGenerationRequest;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OpenAIImageGenerationRequest implements ImageGenerationRequest {
+
+  /**
+   * A text description of the desired image(s). The maximum length is 4000 characters.
+   */
+  @JsonProperty("prompt")
+  private final String prompt;
+
+
+  /**
+   * A text description of the desired image(s). The maximum length is 4000 characters.
+   * </br>
+   * Optional, default values will apply if no value is provided.
+   */
+  @JsonProperty("size")
+  private final ImageSize size;
+
+
+  /**
+   * The number of images to generate.
+   * </br>
+   * Optional, default values will apply if no value is provided.
+   */
+  @JsonProperty("n")
+  private final int numberOfImages;
+
+  /**
+   * The format in which the generated images are returned.
+   * </br>
+   * Optional, default values will apply if no value is provided.
+   */
+  @JsonProperty("response_format")
+  private final ImagesResponseFormat responseFormat;
+
+  /**
+   * The quality of the image that will be generated.
+   * </br>
+   * Optional, default values will apply if no value is provided.
+   */
+  @JsonProperty("quality")
+  private final ImageQuality quality;
+
+  /**
+   * The style of the generated images.
+   * </br>
+   * Optional, default values will apply if no value is provided.
+   */
+  @JsonProperty("style")
+  private final ImageStyle style;
+
+  /**
+   * Custom request path.
+   */
+  @JsonIgnore
+  private final String overriddenPath;
+
+
+
+
+  private OpenAIImageGenerationRequest(Builder builder) {
+    this.prompt = builder.prompt;
+    this.size = builder.size;
+    this.style = builder.style;
+    this.responseFormat = builder.responseFormat;
+    this.quality = builder.quality;
+    this.numberOfImages = builder.numberOfImages;
+    this.overriddenPath = builder.overriddenPath;
+  }
+
+  public String getPrompt() {
+    return prompt;
+  }
+
+  public ImageSize getSize() {
+    return size;
+  }
+
+  public int getNumberOfImages() {
+    return numberOfImages;
+  }
+
+  public ImagesResponseFormat getResponseFormat() {
+    return responseFormat;
+  }
+
+  public ImageQuality getQuality() {
+    return quality;
+  }
+
+  public ImageStyle getStyle() {
+    return style;
+  }
+
+  @JsonIgnore
+  public String getOverriddenPath() {
+    return this.overriddenPath;
+  }
+
+
+  public static class Builder {
+    private String prompt;
+    private ImageSize size;
+    private int numberOfImages;
+    private ImagesResponseFormat responseFormat;
+    private ImageQuality quality;
+    private ImageStyle style;
+    private String overriddenPath;
+
+    public Builder(String prompt) {
+      this.prompt = prompt;
+      this.numberOfImages = 1;
+    }
+
+    public Builder setNumberOfImages(int numberOfImages) {
+      this.numberOfImages = numberOfImages;
+      return this;
+    }
+
+    public Builder setPrompt(String prompt) {
+      this.prompt = prompt;
+      return this;
+    }
+
+    public Builder setSize(ImageSize size) {
+      this.size = size;
+      return this;
+    }
+
+    public Builder setResponseFormat(ImagesResponseFormat responseFormat) {
+      this.responseFormat = responseFormat;
+      return this;
+    }
+
+    public Builder setQuality(ImageQuality quality) {
+      this.quality = quality;
+      return this;
+    }
+
+    public Builder setStyle(ImageStyle style) {
+      this.style = style;
+      return this;
+    }
+
+    public OpenAIImageGenerationRequest build() {
+      return new OpenAIImageGenerationRequest(this);
+    }
+
+    public void setOverriddenPath(String overriddenPath) {
+        this.overriddenPath = overriddenPath;
+    }
+  }
+
+
+  public enum ImageQuality {
+    @JsonEnumDefaultValue
+    STANDARD("standard"),
+    HD("hd");
+
+    private final String quality;
+
+    ImageQuality(String detail) {
+      this.quality = detail;
+    }
+
+    @JsonValue
+    public String getQuality() {
+      return this.quality;
+    }
+  }
+
+  public enum ImageStyle {
+    @JsonEnumDefaultValue
+    VIVID("vivid"),
+    NATURAL("natural");
+
+    private final String style;
+
+    ImageStyle(String detail) {
+      this.style = detail;
+    }
+
+    @JsonValue
+    public String getStyle() {
+      return this.style;
+    }
+  }
+
+  public enum ImagesResponseFormat {
+    @JsonEnumDefaultValue
+    URL("url"),
+    BASE_64_JSON("b64_json");
+
+    private final String responseFormat;
+
+    ImagesResponseFormat(String detail) {
+      this.responseFormat = detail;
+    }
+
+    @JsonValue
+    public String getResponseFormat() {
+      return this.responseFormat;
+    }
+  }
+
+  public enum ImageSize {
+    LANDSCAPE_1792_1024("1792x1024"),
+    PORTRAIT_1024_1792("1024x1792"),
+    @JsonEnumDefaultValue
+    SQUARE_1024_1024("1024x1024");
+
+    private final String size;
+
+    ImageSize(String size) {
+      this.size = size;
+    }
+
+    @JsonValue
+    public String getSize() {
+      return this.size;
+    }
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/openai/imagegen/response/OpenAiImageGenerationResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/imagegen/response/OpenAiImageGenerationResponse.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
 import ee.carlrobert.llm.imagegen.ImageGenerationResponse;
-
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -14,82 +13,85 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenAiImageGenerationResponse implements ImageGenerationResponse {
 
-    @JsonProperty("data")
-    private final List<OpenAiImageGenerationResponseData> data;
+  @JsonProperty("data")
+  private final List<OpenAiImageGenerationResponseData> data;
+
+  @JsonIgnore
+  private final Date created;
+
+  @JsonProperty("error")
+  private final ErrorDetails error;
+
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+  public OpenAiImageGenerationResponse(
+      @JsonProperty("data") List<OpenAiImageGenerationResponseData> data,
+      @JsonProperty("created") Long created,
+      @JsonProperty("error") ErrorDetails error) {
+    this.data = data;
+    this.created =
+        created == null ? null : new Date(created * 1000L); // date is given as unix timestamp
+    this.error = error;
+  }
+
+  public List<OpenAiImageGenerationResponseData> getData() {
+    return data;
+  }
+
+  public ErrorDetails getError() {
+    return error;
+  }
+
+  @JsonIgnore
+  public Date getCreated() {
+    return created;
+  }
+
+  @JsonProperty("created")
+  public Long getCreatedAsLong() {
+    if (created == null) {
+      return null;
+    }
+    return created.getTime() / 1000L;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class OpenAiImageGenerationResponseData implements ImageGenerationResponse {
+
+    @JsonProperty("url")
+    private final String url;
 
     @JsonIgnore
-    private final Date created;
+    private final byte[] imageData;
 
-    @JsonProperty("error")
-    private final ErrorDetails error;
+    @JsonProperty("revised_prompt")
+    private final String revisedPrompt;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public OpenAiImageGenerationResponse(@JsonProperty("data") List<OpenAiImageGenerationResponseData> data,
-                                         @JsonProperty("created") Long created,
-                                         @JsonProperty("error") ErrorDetails error) {
-        this.data = data;
-        this.created = created == null ? null : new Date(created * 1000L); // date is given as unix timestamp
-        this.error = error;
+    public OpenAiImageGenerationResponseData(
+        @JsonProperty("url") String url,
+        @JsonProperty("b64_json") String base64json,
+        @JsonProperty("revised_prompt") String revisedPrompt) {
+      this.url = url;
+      this.imageData = base64json == null ? null : Base64.getDecoder().decode(base64json);
+      this.revisedPrompt = revisedPrompt;
     }
 
-    public List<OpenAiImageGenerationResponseData> getData() {
-        return data;
-    }
-
-    public ErrorDetails getError() {
-        return error;
+    public String getUrl() {
+      return url;
     }
 
     @JsonIgnore
-    public Date getCreated() {
-        return created;
+    public byte[] getImageData() {
+      return this.imageData;
     }
 
-    @JsonProperty("created")
-    public Long getCreatedAsLong() {
-        if (created == null) {
-            return null;
-        }
-        return created.getTime() / 1000L;
+    @JsonProperty("b64_json")
+    public String getImageDataBase64() {
+      return this.imageData == null ? null : Base64.getEncoder().encodeToString(this.imageData);
     }
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class OpenAiImageGenerationResponseData implements ImageGenerationResponse {
-        @JsonProperty("url")
-        private final String url;
-
-        @JsonIgnore
-        private final byte[] imageData;
-
-        @JsonProperty("revised_prompt")
-        private final String revisedPrompt;
-
-        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        public OpenAiImageGenerationResponseData(
-                @JsonProperty("url") String url,
-                @JsonProperty("b64_json") String base64json,
-                @JsonProperty("revised_prompt") String revisedPrompt) {
-            this.url = url;
-            this.imageData = base64json == null ? null : Base64.getDecoder().decode(base64json);
-            this.revisedPrompt = revisedPrompt;
-        }
-
-        public String getUrl() {
-            return url;
-        }
-
-        @JsonIgnore
-        public byte[] getImageData() {
-            return this.imageData;
-        }
-
-        @JsonProperty("b64_json")
-        public String getImageDataBase64() {
-            return this.imageData == null ? null : Base64.getEncoder().encodeToString(this.imageData);
-        }
-
-        public String getRevisedPrompt() {
-            return revisedPrompt;
-        }
+    public String getRevisedPrompt() {
+      return revisedPrompt;
     }
+  }
 }

--- a/src/main/java/ee/carlrobert/llm/client/openai/imagegen/response/OpenAiImageGenerationResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/imagegen/response/OpenAiImageGenerationResponse.java
@@ -1,0 +1,98 @@
+package ee.carlrobert.llm.client.openai.imagegen.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
+import ee.carlrobert.llm.imagegen.ImageGenerationResponse;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OpenAiImageGenerationResponse implements ImageGenerationResponse {
+
+    @JsonProperty("data")
+    private final List<OpenAiImageGenerationResponseData> data;
+
+    @JsonIgnore
+    private final Date created;
+
+    @JsonProperty("error")
+    private final ErrorDetails error;
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public OpenAiImageGenerationResponse(@JsonProperty("data") List<OpenAiImageGenerationResponseData> data,
+                                         @JsonProperty("created") Long created,
+                                         @JsonProperty("error") ErrorDetails error) {
+        this.data = data;
+        this.created = created == null ? null : new Date(created * 1000L); // date is given as unix timestamp
+        this.error = error;
+    }
+
+    public List<OpenAiImageGenerationResponseData> getData() {
+        return data;
+    }
+
+    public ErrorDetails getError() {
+        return error;
+    }
+
+    @JsonIgnore
+    public Date getCreated() {
+        return created;
+    }
+
+    @JsonProperty("created")
+    public Long getCreatedAsLong() {
+        if (created == null) {
+            return null;
+        }
+        return created.getTime() / 1000L;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class OpenAiImageGenerationResponseData implements ImageGenerationResponse {
+        @JsonProperty("url")
+        private final String url;
+
+        @JsonIgnore
+        private final byte[] imageData;
+
+        @JsonProperty("revised_prompt")
+        private final String revisedPrompt;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public OpenAiImageGenerationResponseData(
+                @JsonProperty("url") String url,
+                @JsonProperty("b64_json") String base64json,
+                @JsonProperty("revised_prompt") String revisedPrompt) {
+            this.url = url;
+            this.imageData = base64json == null ? null : Base64.getDecoder().decode(base64json);
+            this.revisedPrompt = revisedPrompt;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        @JsonIgnore
+        public byte[] getImageData() {
+            return this.imageData;
+        }
+
+        @JsonProperty("b64_json")
+        public String getImageDataBase64() {
+            return this.imageData == null ? null : Base64.getEncoder().encodeToString(this.imageData);
+        }
+
+        public String getRevisedPrompt() {
+            return revisedPrompt;
+        }
+    }
+}

--- a/src/main/java/ee/carlrobert/llm/client/openai/imagegen/response/OpenAiImageGenerationResponse.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/imagegen/response/OpenAiImageGenerationResponse.java
@@ -7,9 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
 import ee.carlrobert.llm.imagegen.ImageGenerationResponse;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/ee/carlrobert/llm/imagegen/ImageGenerationModel.java
+++ b/src/main/java/ee/carlrobert/llm/imagegen/ImageGenerationModel.java
@@ -1,0 +1,7 @@
+package ee.carlrobert.llm.imagegen;
+
+public interface ImageGenerationModel {
+  String getCode();
+
+  String getDescription();
+}

--- a/src/main/java/ee/carlrobert/llm/imagegen/ImageGenerationRequest.java
+++ b/src/main/java/ee/carlrobert/llm/imagegen/ImageGenerationRequest.java
@@ -1,0 +1,4 @@
+package ee.carlrobert.llm.imagegen;
+
+public interface ImageGenerationRequest {
+}

--- a/src/main/java/ee/carlrobert/llm/imagegen/ImageGenerationResponse.java
+++ b/src/main/java/ee/carlrobert/llm/imagegen/ImageGenerationResponse.java
@@ -1,0 +1,4 @@
+package ee.carlrobert.llm.imagegen;
+
+public interface ImageGenerationResponse {
+}

--- a/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
@@ -95,7 +95,7 @@ class AzureClientTest extends BaseTest {
     var prompt = "TEST_PROMPT";
     expectAzure((BasicHttpExchange) request -> {
       assertThat(request.getUri().getPath()).isEqualTo(
-          "/openai/deployments/TEST_DEPLOYMENT_ID/images/generations");
+          "/openai/deployments/dalle3/images/generations");
       assertThat(request.getMethod()).isEqualTo("POST");
       assertThat(request.getHeaders().get("Authorization").get(0))
           .isEqualTo("Bearer TEST_API_KEY");
@@ -106,12 +106,14 @@ class AzureClientTest extends BaseTest {
               "n",
               "quality",
               "response_format",
-              "style")
+              "style",
+              "model")
           .containsExactly(
               2,
               OpenAIImageGenerationRequest.ImageQuality.STANDARD.getQuality(),
               OpenAIImageGenerationRequest.ImagesResponseFormat.URL.getResponseFormat(),
-              OpenAIImageGenerationRequest.ImageStyle.VIVID.getStyle());
+              OpenAIImageGenerationRequest.ImageStyle.VIVID.getStyle(),
+              "dalle3");
       return new ResponseEntity(new ObjectMapper().writeValueAsString(
           Map.of("data", List.of(Map.of("url", "url-to-image",
               "revised_prompt", "revised-prompt-value")))));
@@ -127,6 +129,7 @@ class AzureClientTest extends BaseTest {
         .build()
         .getImageGeneration(new OpenAIImageGenerationRequest.Builder(prompt)
             .setNumberOfImages(2)
+            .setModel("dalle3")
             .setQuality(OpenAIImageGenerationRequest.ImageQuality.STANDARD)
             .setResponseFormat(OpenAIImageGenerationRequest.ImagesResponseFormat.URL)
             .setStyle(OpenAIImageGenerationRequest.ImageStyle.VIVID)

--- a/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
@@ -18,6 +18,7 @@ import ee.carlrobert.llm.client.http.exchange.StreamHttpExchange;
 import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
 import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionRequest;
 import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionStandardMessage;
+import ee.carlrobert.llm.client.openai.imagegen.request.OpenAIImageGenerationRequest;
 import ee.carlrobert.llm.completion.CompletionEventListener;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +90,56 @@ class AzureClientTest extends BaseTest {
     await().atMost(5, SECONDS).until(() -> "Hello!".contentEquals(resultMessageBuilder));
   }
 
+    @Test
+    void shouldGetAzureImageGeneration() {
+        var prompt = "TEST_PROMPT";
+        expectAzure((BasicHttpExchange) request -> {
+            assertThat(request.getUri().getPath()).isEqualTo(
+                    "/openai/deployments/TEST_DEPLOYMENT_ID/images/generations");
+            assertThat(request.getMethod()).isEqualTo("POST");
+            assertThat(request.getHeaders().get("Authorization").get(0))
+                    .isEqualTo("Bearer TEST_API_KEY");
+            assertThat(request.getHeaders().get("X-llm-application-tag").get(0))
+                    .isEqualTo("codegpt");
+            assertThat(request.getBody())
+                    .extracting(
+                            "n",
+                            "quality",
+                            "response_format",
+                            "style")
+                    .containsExactly(
+                            2,
+                            OpenAIImageGenerationRequest.ImageQuality.STANDARD.getQuality(),
+                            OpenAIImageGenerationRequest.ImagesResponseFormat.URL.getResponseFormat(),
+                            OpenAIImageGenerationRequest.ImageStyle.VIVID.getStyle());
+            return new ResponseEntity(new ObjectMapper().writeValueAsString(
+                    Map.of("data", List.of(Map.of("url", "url-to-image",
+                            "revised_prompt", "revised-prompt-value")))));
+        });
+
+        var response = new AzureClient.Builder(
+                "TEST_API_KEY",
+                new AzureCompletionRequestParams(
+                        "TEST_RESOURCE",
+                        "TEST_DEPLOYMENT_ID",
+                        "TEST_API_VERSION"))
+                .setActiveDirectoryAuthentication(true)
+                .build()
+                .getImageGeneration(new OpenAIImageGenerationRequest.Builder(prompt)
+                        .setNumberOfImages(2)
+                        .setQuality(OpenAIImageGenerationRequest.ImageQuality.STANDARD)
+                        .setResponseFormat(OpenAIImageGenerationRequest.ImagesResponseFormat.URL)
+                        .setStyle(OpenAIImageGenerationRequest.ImageStyle.VIVID)
+                        .build());
+
+
+        assertThat(response)
+                .extracting("data")
+                .extracting(result -> ((List<?>) result).get(0))
+                .extracting("url", "revisedPrompt")
+                .containsExactly("url-to-image","revised-prompt-value");
+    }
+
   @Test
   void shouldGetAzureChatCompletion() {
     var prompt = "TEST_PROMPT";
@@ -121,7 +172,10 @@ class AzureClientTest extends BaseTest {
 
     var response = new AzureClient.Builder(
         "TEST_API_KEY",
-        new AzureCompletionRequestParams("TEST_RESOURCE", "TEST_DEPLOYMENT_ID", "TEST_API_VERSION"))
+        new AzureCompletionRequestParams(
+                "TEST_RESOURCE",
+                "TEST_DEPLOYMENT_ID",
+                "TEST_API_VERSION"))
         .setActiveDirectoryAuthentication(true)
         .build()
         .getChatCompletion(new OpenAIChatCompletionRequest.Builder(

--- a/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
@@ -127,7 +127,7 @@ class AzureClientTest extends BaseTest {
             "TEST_API_VERSION"))
         .setActiveDirectoryAuthentication(true)
         .build()
-        .getImageGeneration(new OpenAIImageGenerationRequest.Builder(prompt)
+        .getImage(new OpenAIImageGenerationRequest.Builder(prompt)
             .setNumberOfImages(2)
             .setModel("dalle3")
             .setQuality(OpenAIImageGenerationRequest.ImageQuality.STANDARD)

--- a/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
+++ b/src/test/java/ee/carlrobert/llm/client/AzureClientTest.java
@@ -90,55 +90,54 @@ class AzureClientTest extends BaseTest {
     await().atMost(5, SECONDS).until(() -> "Hello!".contentEquals(resultMessageBuilder));
   }
 
-    @Test
-    void shouldGetAzureImageGeneration() {
-        var prompt = "TEST_PROMPT";
-        expectAzure((BasicHttpExchange) request -> {
-            assertThat(request.getUri().getPath()).isEqualTo(
-                    "/openai/deployments/TEST_DEPLOYMENT_ID/images/generations");
-            assertThat(request.getMethod()).isEqualTo("POST");
-            assertThat(request.getHeaders().get("Authorization").get(0))
-                    .isEqualTo("Bearer TEST_API_KEY");
-            assertThat(request.getHeaders().get("X-llm-application-tag").get(0))
-                    .isEqualTo("codegpt");
-            assertThat(request.getBody())
-                    .extracting(
-                            "n",
-                            "quality",
-                            "response_format",
-                            "style")
-                    .containsExactly(
-                            2,
-                            OpenAIImageGenerationRequest.ImageQuality.STANDARD.getQuality(),
-                            OpenAIImageGenerationRequest.ImagesResponseFormat.URL.getResponseFormat(),
-                            OpenAIImageGenerationRequest.ImageStyle.VIVID.getStyle());
-            return new ResponseEntity(new ObjectMapper().writeValueAsString(
-                    Map.of("data", List.of(Map.of("url", "url-to-image",
-                            "revised_prompt", "revised-prompt-value")))));
-        });
+  @Test
+  void shouldGetAzureImageGeneration() {
+    var prompt = "TEST_PROMPT";
+    expectAzure((BasicHttpExchange) request -> {
+      assertThat(request.getUri().getPath()).isEqualTo(
+          "/openai/deployments/TEST_DEPLOYMENT_ID/images/generations");
+      assertThat(request.getMethod()).isEqualTo("POST");
+      assertThat(request.getHeaders().get("Authorization").get(0))
+          .isEqualTo("Bearer TEST_API_KEY");
+      assertThat(request.getHeaders().get("X-llm-application-tag").get(0))
+          .isEqualTo("codegpt");
+      assertThat(request.getBody())
+          .extracting(
+              "n",
+              "quality",
+              "response_format",
+              "style")
+          .containsExactly(
+              2,
+              OpenAIImageGenerationRequest.ImageQuality.STANDARD.getQuality(),
+              OpenAIImageGenerationRequest.ImagesResponseFormat.URL.getResponseFormat(),
+              OpenAIImageGenerationRequest.ImageStyle.VIVID.getStyle());
+      return new ResponseEntity(new ObjectMapper().writeValueAsString(
+          Map.of("data", List.of(Map.of("url", "url-to-image",
+              "revised_prompt", "revised-prompt-value")))));
+    });
 
-        var response = new AzureClient.Builder(
-                "TEST_API_KEY",
-                new AzureCompletionRequestParams(
-                        "TEST_RESOURCE",
-                        "TEST_DEPLOYMENT_ID",
-                        "TEST_API_VERSION"))
-                .setActiveDirectoryAuthentication(true)
-                .build()
-                .getImageGeneration(new OpenAIImageGenerationRequest.Builder(prompt)
-                        .setNumberOfImages(2)
-                        .setQuality(OpenAIImageGenerationRequest.ImageQuality.STANDARD)
-                        .setResponseFormat(OpenAIImageGenerationRequest.ImagesResponseFormat.URL)
-                        .setStyle(OpenAIImageGenerationRequest.ImageStyle.VIVID)
-                        .build());
+    var response = new AzureClient.Builder(
+        "TEST_API_KEY",
+        new AzureCompletionRequestParams(
+            "TEST_RESOURCE",
+            "TEST_DEPLOYMENT_ID",
+            "TEST_API_VERSION"))
+        .setActiveDirectoryAuthentication(true)
+        .build()
+        .getImageGeneration(new OpenAIImageGenerationRequest.Builder(prompt)
+            .setNumberOfImages(2)
+            .setQuality(OpenAIImageGenerationRequest.ImageQuality.STANDARD)
+            .setResponseFormat(OpenAIImageGenerationRequest.ImagesResponseFormat.URL)
+            .setStyle(OpenAIImageGenerationRequest.ImageStyle.VIVID)
+            .build());
 
-
-        assertThat(response)
-                .extracting("data")
-                .extracting(result -> ((List<?>) result).get(0))
-                .extracting("url", "revisedPrompt")
-                .containsExactly("url-to-image","revised-prompt-value");
-    }
+    assertThat(response)
+        .extracting("data")
+        .extracting(result -> ((List<?>) result).get(0))
+        .extracting("url", "revisedPrompt")
+        .containsExactly("url-to-image", "revised-prompt-value");
+  }
 
   @Test
   void shouldGetAzureChatCompletion() {


### PR DESCRIPTION
This adds image generation support for Azure and OpenAI as suggested in #41 

Usage with Azure:

```java
    AzureClient azureClient = new AzureClient.Builder("my-api-key",
        new AzureCompletionRequestParams(
            "my-company-resource-name",
            "gpt-4o",
            "2024-02-01"))
        .build();

    final OpenAiImageGenerationResponse imageOfACat = azureClient.getImageGeneration(
        new OpenAIImageGenerationRequest.Builder("Image of a cat")
            .setResponseFormat(OpenAIImageGenerationRequest.ImagesResponseFormat.URL)
            .setNumberOfImages(1)
            .setModel("dalle3") // Must be name of deployment for the image generation model
            .setQuality(OpenAIImageGenerationRequest.ImageQuality.STANDARD)
            .setStyle(OpenAIImageGenerationRequest.ImageStyle.NATURAL)
            .setSize(OpenAIImageGenerationRequest.ImageSize.SQUARE_1024_1024).build());

    if (imageOfACat.getError() != null) {
      System.out.println(imageOfACat.getError().getMessage());
    } else {
      System.out.println(imageOfACat.getData().get(0).getUrl());
    }
```

Usage with OpenAi:

```java
    OpenAIClient openAiClient = new OpenAIClient.Builder(
        "my-api-key")
        .build();

    final OpenAiImageGenerationResponse imageOfACat = openAiClient.getImageGeneration(
        new OpenAIImageGenerationRequest.Builder("Image of a cat")
            .setResponseFormat(OpenAIImageGenerationRequest.ImagesResponseFormat.URL)
            .setNumberOfImages(1)
            .setModel(
                OpenAIImageGenerationModel.DALL_E_3.getCode()) // Uses default model, if not set
            .setQuality(OpenAIImageGenerationRequest.ImageQuality.STANDARD)
            .setStyle(OpenAIImageGenerationRequest.ImageStyle.NATURAL)
            .setSize(OpenAIImageGenerationRequest.ImageSize.SQUARE_1024_1024).build());

    if (imageOfACat.getError() != null) {
      System.out.println(imageOfACat.getError().getMessage());
    } else {
      System.out.println(imageOfACat.getData().get(0).getUrl());
    }
```


Basic usage with only the required settings in OpenAi:

```java
    OpenAIClient openAiClient = new OpenAIClient.Builder(
        "my-api-key")
        .build();

    final OpenAiImageGenerationResponse imageOfACat = openAiClient.getImageGeneration(
        new OpenAIImageGenerationRequest.Builder("Image of a cat").build());

    if (imageOfACat.getError() != null) {
      System.out.println(imageOfACat.getError().getMessage());
    } else {
      System.out.println(imageOfACat.getData().get(0).getUrl());
    }
```