### PR TITLE
Fix Google Response parsing + update Model

### DIFF
--- a/src/main/java/ee/carlrobert/llm/client/google/GoogleClient.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/GoogleClient.java
@@ -290,7 +290,13 @@ public class GoogleClient {
               .getCandidates();
           return (candidates == null ? Stream.<Candidate>empty() : candidates.stream())
               .filter(Objects::nonNull)
-              .flatMap(candidate -> candidate.getContent().getParts().stream())
+              .flatMap(candidate -> {
+                // when finishReason = MAX_TOKENS, the content does not have a "parts" field
+                if (candidate.getContent() != null && candidate.getContent().getParts() != null) {
+                  return candidate.getContent().getParts().stream();
+                }
+                return Stream.empty();
+              })
               .filter(Objects::nonNull)
               .findFirst()
               .map(GoogleContentPart::getText)

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionContent.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionContent.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * See <a href="https://ai.google.dev/api/caching?authuser=1&hl=en#Content">Content</a>.
+ */
 @JsonInclude(Include.NON_NULL)
 public class GoogleCompletionContent {
 

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionRequest.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleCompletionRequest.java
@@ -4,16 +4,21 @@ import ee.carlrobert.llm.completion.CompletionRequest;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * See <a href="https://ai.google.dev/api/generate-content?hl=en&authuser=1#request-body">Request-Body</a>.
+ */
 public class GoogleCompletionRequest implements CompletionRequest {
 
   private final List<GoogleCompletionContent> contents;
   private final List<SafetySetting> safetySettings;
   private final GoogleGenerationConfig generationConfig;
+  private final GoogleCompletionContent systemInstruction;
 
   public GoogleCompletionRequest(Builder builder) {
     this.contents = builder.contents;
     this.safetySettings = builder.safetySettings;
     this.generationConfig = builder.generationConfig;
+    this.systemInstruction = builder.systemInstruction;
   }
 
   public List<GoogleCompletionContent> getContents() {
@@ -26,6 +31,10 @@ public class GoogleCompletionRequest implements CompletionRequest {
 
   public GoogleGenerationConfig getGenerationConfig() {
     return generationConfig;
+  }
+
+  public GoogleCompletionContent getSystemInstruction() {
+    return systemInstruction;
   }
 
   /**
@@ -81,6 +90,7 @@ public class GoogleCompletionRequest implements CompletionRequest {
     private List<GoogleCompletionContent> contents;
     private List<SafetySetting> safetySettings = new ArrayList<>();
     private GoogleGenerationConfig generationConfig = new GoogleGenerationConfig.Builder().build();
+    private GoogleCompletionContent systemInstruction = null;
 
     public Builder(List<GoogleCompletionContent> contents) {
       this.contents = contents;
@@ -93,6 +103,16 @@ public class GoogleCompletionRequest implements CompletionRequest {
 
     public Builder generationConfig(GoogleGenerationConfig generationConfig) {
       this.generationConfig = generationConfig;
+      return this;
+    }
+
+    public Builder systemInstruction(GoogleCompletionContent systemInstruction) {
+      this.systemInstruction = systemInstruction;
+      return this;
+    }
+
+    public Builder systemInstruction(String systemInstruction) {
+      this.systemInstruction = new GoogleCompletionContent(List.of(systemInstruction));
       return this;
     }
 

--- a/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleContentPart.java
+++ b/src/main/java/ee/carlrobert/llm/client/google/completion/GoogleContentPart.java
@@ -5,22 +5,31 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.Base64;
 import java.util.Base64.Encoder;
 
+/**
+ * See <a href="https://ai.google.dev/api/caching?authuser=1&hl=en#Part">Part</a>.
+ */
 @JsonInclude(Include.NON_NULL)
 public class GoogleContentPart {
 
   private String text;
   private Blob inlineData;
+  private Boolean thought;
 
   public GoogleContentPart() {
   }
 
   public GoogleContentPart(String text) {
-    this(text, null);
+    this(text, null, null);
   }
 
   public GoogleContentPart(String text, Blob inlineData) {
+    this(text, inlineData, null);
+  }
+
+  public GoogleContentPart(String text, Blob inlineData, Boolean thought) {
     this.text = text;
     this.inlineData = inlineData;
+    this.thought = thought;
   }
 
   public String getText() {
@@ -37,6 +46,14 @@ public class GoogleContentPart {
 
   public void setInlineData(Blob inlineData) {
     this.inlineData = inlineData;
+  }
+
+  public Boolean getThought() {
+    return thought;
+  }
+
+  public void setThought(Boolean thought) {
+    this.thought = thought;
   }
 
   /**


### PR DESCRIPTION
- Google's API now offers to set the system prompt via the `systemInstruction` field
- `thought` defines if the sent content is thought of a reasoning model or actual completion content
- When max tokens is reached the response contents does not include `parts` value:
  ```json
  {
    "candidates" : [ {
      "content" : {
        "role" : "model"
      },
      "finishReason" : "MAX_TOKENS",
      "index" : 0
    } ],
    "usageMetadata" : {
      "promptTokenCount" : 333780,
      "candidatesTokenCount" : 2048,
      "totalTokenCount" : 335828,
      "promptTokensDetails" : [ {
        "modality" : "TEXT",
        "tokenCount" : 333780
      } ],
      "thoughtsTokenCount" : 1986
    },
    "modelVersion" : "gemini-2.5-pro-exp-03-25"
  }
  ```

Btw. it would probably be best in the future to just use the DTO's from Google's official https://github.com/googleapis/java-genai 