### PR TITLE
Refactor message extraction to support reasoning content

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "ee.carlrobert"
-version = "0.8.38"
+version = "0.8.39"
 
 repositories {
     mavenCentral()

--- a/src/main/java/ee/carlrobert/llm/client/openai/completion/CompletionDeltaModel.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/completion/CompletionDeltaModel.java
@@ -1,0 +1,23 @@
+package ee.carlrobert.llm.client.openai.completion;
+
+import org.jetbrains.annotations.Nullable;
+
+class CompletionDeltaModel {
+  @Nullable String reasoningContent;
+  @Nullable String content;
+
+  public CompletionDeltaModel(@Nullable String reasoningContent, @Nullable String content) {
+    this.reasoningContent = reasoningContent;
+    this.content = content;
+  }
+
+  @Nullable
+  public String getReasoningContent() {
+    return reasoningContent;
+  }
+
+  @Nullable
+  public String getContent() {
+    return content;
+  }
+}

--- a/src/main/java/ee/carlrobert/llm/client/openai/completion/OpenAIChatCompletionEventSourceListener.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/completion/OpenAIChatCompletionEventSourceListener.java
@@ -1,49 +1,91 @@
 package ee.carlrobert.llm.client.openai.completion;
 
-import static ee.carlrobert.llm.client.DeserializationUtil.OBJECT_MAPPER;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import ee.carlrobert.llm.client.openai.completion.response.OpenAIChatCompletionResponse;
 import ee.carlrobert.llm.client.openai.completion.response.OpenAIChatCompletionResponseChoice;
-import ee.carlrobert.llm.client.openai.completion.response.OpenAIChatCompletionResponseChoiceDelta;
 import ee.carlrobert.llm.completion.CompletionEventListener;
 import ee.carlrobert.llm.completion.CompletionEventSourceListener;
+
 import java.util.Objects;
-import java.util.stream.Stream;
+
+import static ee.carlrobert.llm.client.DeserializationUtil.OBJECT_MAPPER;
 
 public class OpenAIChatCompletionEventSourceListener extends CompletionEventSourceListener<String> {
+
+  private CompletionDeltaModel prevCompletionDeltaModel = null;
 
   public OpenAIChatCompletionEventSourceListener(CompletionEventListener<String> listener) {
     super(listener);
   }
 
   /**
-   * Content of the first choice.
+   * Returns the first valid message content extracted from the OpenAI Chat Completion response.
+   *
+   * <p>This method implements the following new logic:
    * <ul>
-   *     <li>Search all choices which are not null</li>
-   *     <li>Search all deltas which are not null</li>
-   *     <li>Use first content which is not null or blank (whitespace)</li>
-   *     <li>Otherwise use "" (empty string) if no match can be found</li>
+   *   <li>Deserializes the provided JSON string into an {@code OpenAIChatCompletionResponse}.</li>
+   *   <li>Retrieves the list of choices and filters out any null elements.</li>
+   *   <li>For each valid choice, obtains the delta and inspects its fields:
+   *       <ul>
+   *         <li>If {@code reasoningContent} is available, wraps it into a delta model with only the reasoning set.</li>
+   *         <li>Otherwise, wraps the {@code content} field into a delta model.</li>
+   *       </ul>
+   *   </li>
+   *   <li>Chooses the first delta model with a non-null, non-blank content; if none is found, defaults to an empty string.</li>
+   *   <li>Formats the output message:
+   *       <ul>
+   *         <li>Prepends an opening {@code <think>} tag when initiating reasoning content.</li>
+   *         <li>Appends a closing {@code </think>} tag and new line characters if transitioning from reasoning to normal content.</li>
+   *       </ul>
+   *   </li>
    * </ul>
    *
-   * @return First non-blank content which can be found, otherwise {@code ""}
+   * @param data the JSON string received from the OpenAI Chat Completion API.
+   * @return the formatted message extracted from the first valid delta model or an empty string if no matching content is found.
+   * @throws JsonProcessingException if an error occurs during JSON processing.
    */
   protected String getMessage(String data) throws JsonProcessingException {
-    var choices = OBJECT_MAPPER
-        .readValue(data, OpenAIChatCompletionResponse.class)
-        .getChoices();
-    return (choices == null ? Stream.<OpenAIChatCompletionResponseChoice>empty() : choices.stream())
+    var response = OBJECT_MAPPER.readValue(data, OpenAIChatCompletionResponse.class);
+    var choices = response.getChoices();
+
+    CompletionDeltaModel completionDeltaModel = choices == null ? new CompletionDeltaModel(null, "") : choices.stream()
             .filter(Objects::nonNull)
             .map(OpenAIChatCompletionResponseChoice::getDelta)
             .filter(Objects::nonNull)
-            .map(OpenAIChatCompletionResponseChoiceDelta::getContent)
-            .filter(Objects::nonNull)
+            .map(delta ->
+                    delta.getReasoningContent() != null
+                            ? new CompletionDeltaModel(delta.getReasoningContent(), null)
+                            : new CompletionDeltaModel(null, delta.getContent())
+            )
             .findFirst()
-            .orElse("");
+            .orElse(new CompletionDeltaModel(null, ""));
+
+    return getMessageFromDeltaModel(completionDeltaModel);
   }
 
   @Override
   protected ErrorDetails getErrorDetails(String data) throws JsonProcessingException {
     return OBJECT_MAPPER.readValue(data, ApiResponseError.class).getError();
+  }
+
+  private String getMessageFromDeltaModel(CompletionDeltaModel completionDeltaModel) {
+    StringBuilder sb = new StringBuilder();
+    String reasoning = completionDeltaModel.getReasoningContent();
+    String content = completionDeltaModel.getContent();
+
+    if (reasoning != null) {
+      if (prevCompletionDeltaModel == null || prevCompletionDeltaModel.getReasoningContent() == null) {
+        sb.append("<think>");
+      }
+      sb.append(reasoning);
+    } else if (content != null) {
+      if (prevCompletionDeltaModel != null && prevCompletionDeltaModel.getReasoningContent() != null) {
+        sb.append("</think>\n\n");
+      }
+      sb.append(content);
+    }
+
+    prevCompletionDeltaModel = completionDeltaModel;
+    return sb.toString();
   }
 }

--- a/src/main/java/ee/carlrobert/llm/client/openai/completion/response/OpenAIChatCompletionResponseChoiceDelta.java
+++ b/src/main/java/ee/carlrobert/llm/client/openai/completion/response/OpenAIChatCompletionResponseChoiceDelta.java
@@ -10,16 +10,19 @@ public class OpenAIChatCompletionResponseChoiceDelta {
 
   private final String role;
   private final String content;
+  private final String reasoningContent;
   private final List<ToolCall> toolCalls;
 
   @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
   public OpenAIChatCompletionResponseChoiceDelta(
       @JsonProperty("role") String role,
       @JsonProperty("content") String content,
+      @JsonProperty("reasoning_content") String reasoningContent,
       @JsonProperty("tool_calls") List<ToolCall> toolCalls) {
     this.role = role;
     this.content = content;
     this.toolCalls = toolCalls;
+    this.reasoningContent = reasoningContent;
   }
 
   public String getRole() {
@@ -32,5 +35,9 @@ public class OpenAIChatCompletionResponseChoiceDelta {
 
   public List<ToolCall> getToolCalls() {
     return toolCalls;
+  }
+
+  public String getReasoningContent() {
+    return reasoningContent;
   }
 }


### PR DESCRIPTION
• Introduce CompletionDeltaModel to encapsulate reasoning and standard content. • Update OpenAIChatCompletionEventSourceListener to wrap reasoning text with <think> tags and properly transition to normal content. • Update JSON deserialization in OpenAIChatCompletionResponseChoiceDelta to extract reasoning_content. • Bump version to 0.8.39.